### PR TITLE
Upgrade/TranslationManyToManyDescriptor

### DIFF
--- a/djangoplicity/translation/related_descriptors.py
+++ b/djangoplicity/translation/related_descriptors.py
@@ -342,10 +342,10 @@ class TranslationManyToManyDescriptor(ManyToManyDescriptor, TranslationDescripto
     def related_manager_cls(self):
         '''
         Copied from ManyToManyDescriptor.related_manager_cls,
-        Replace model._default_manager.__class__ by self.get_manager_base_class(related_model=self.field.remote_field.to)
+        Replace model._default_manager.__class__ by self.get_manager_base_class(related_model=self.field.remote_field.model)
         '''
         return create_forward_many_to_many_manager(
-            self.get_manager_base_class(related_model=self.field.remote_field.to),  # Updated
+            self.get_manager_base_class(related_model=self.field.remote_field.model),  # Updated
             self.rel,
             reverse=self.reverse,
         )


### PR DESCRIPTION
`ForeignObjectRel.to` was removed in Django 2 in favor of `ForeignObjectRel.model`
See: https://github.com/django/django/blob/stable/1.11.x/django/db/models/fields/reverse_related.py
And: https://github.com/django/django/blob/stable/2.0.x/django/db/models/fields/reverse_related.py