### PR TITLE
Fix: wrong parameter value in the import builtin function

### DIFF
--- a/djangoplicity/media/models/videos.py
+++ b/djangoplicity/media/models/videos.py
@@ -220,7 +220,7 @@ class Video( ArchiveModel, TranslationModel, ContentDeliveryModel ):
                 # Try to see if we have a workflow that we need to run.
                 (name, func) = settings.ARCHIVE_WORKFLOWS['media.video.rename']
                 # Try to import the module and run the function
-                module = __import__(name, globals(), locals(), [func, ], -1)
+                module = __import__(name, globals(), locals(), [func, ], 0)
                 getattr(module, func)(pk=self.pk, new_pk=new_pk)
         except (AttributeError, KeyError):
             pass


### PR DESCRIPTION
## Fix information

The docs (3.9 version) for __import__ are the most confusing of the built-in functions:

```
__import__(...)
    __import__(name, globals=None, locals=None, fromlist=(), level=0) -> module

    Import a module. Because this function is meant for use by the Python
    interpreter and not for general use it is better to use
    importlib.import_module() to programmatically import a module.

    The globals argument is only used to determine the context;
    they are not modified.  The locals argument is unused.  The fromlist
    should be a list of names to emulate ''from name import ...'', or an
    empty list to emulate ''import name''.
    When importing a module from a package, note that __import__('A.B', ...)
    returns package A when fromlist is empty, but its submodule B when
    fromlist is not empty.  Level is used to determine whether to perform 
    absolute or relative imports. 0 is absolute while a positive number
    is the number of parent directories to search relative to the current module.
```

The line of code in version 2 of python is:

```
module = __import__(name, globals(), locals(), [func, ], -1)
```

The value -1 for the level parameter generates an error according to the information in the following logs:

```
Internal Server Error: /admin/media/video/heic2109c/change/rename/

ValueError at /admin/media/video/heic2109c/change/rename/
level must be >= 0

Request Method: POST
Request URL: http://esahubble.org/admin/media/video/heic2109c/change/rename/
Django Version: 2.2.16
Python Executable: /usr/local/bin/python
Python Version: 3.8.12
Python Path: ['/home/hubbleadm', '/home/hubbleadm', '/home/hubbleadm/.local/bin', '/usr/local/lib/python38.zip', '/usr/local/lib/python3.8', '/usr/local/lib/python3.8/lib-dynload', '/home/hubbleadm/.local/lib/python3.8/site-packages', '/usr/local/lib/python3.8/site-packages']
Server time: Mon, 20 Sep 2021 17:09:25 +0200
```

The proposed solution is to leave the default value to the parameter:

```
module = __import__(name, globals(), locals(), [func, ], 0)
```

> Since the documentation assigns a default value in the definition of a function, sending the value 0 could simply be omitted