### PR TITLE
Image missing a text alternative

### DIFF
--- a/djangoplicity/templates/audiotracks/embedded_list.html
+++ b/djangoplicity/templates/audiotracks/embedded_list.html
@@ -3,8 +3,8 @@
 <h3 class="archivegrouptitle">{% trans "Audio" %}</h3>
 {% for track in object.videoaudiotrack_set.all %}
 <div class="archive_download">
-    <span class="archive_dl_icon"><img src="{% static "icons/icon_audio.png" %}" /></span>
-    <span class="archive_dl_text"><a href="{{ track.resource_audio.url }}"{{track.resource_audio.extra_attrs}}>{{track|safe}}</a></span>
+    <span class="archive_dl_icon"><img src="{% static "icons/icon_audio.png" %}"  alt="Audio Icon"/></span>
+    <span class="archive_dl_text"><a href="{{ track.resource_audio.url }}"{{track.resource_audio.extra_attrs}} aria-label="{{ track|safe }}">{{track|safe}}</a></span>
     {% if track.resource_audio.size %}<span class="archive_dl_size"><div>{{track.resource_audio.size|filesizeformat}}</div></span>{% endif %}
 </div>
 {% endfor %}

--- a/djangoplicity/templates/broadcastaudiotracks/embedded_list.html
+++ b/djangoplicity/templates/broadcastaudiotracks/embedded_list.html
@@ -5,8 +5,8 @@
     {% for track in object.videobroadcastaudiotrack_set.all %}
         {% if track.resource_broadcastaudio %}
         <div class="archive_download">
-            <span class="archive_dl_icon"><img src="{% static "icons/icon_audio.png" %}" /></span>
-            <span class="archive_dl_text"><a href="{{ track.resource_broadcastaudio.url }}"{{ track.resource_broadcastaudio.extra_attrs }}>{{ track|safe }}</a></span>
+            <span class="archive_dl_icon"><img src="{% static "icons/icon_audio.png" %}" alt="Audio Icon"/></span>
+            <span class="archive_dl_text"><a href="{{ track.resource_broadcastaudio.url }}"{{ track.resource_broadcastaudio.extra_attrs }} aria-label="{{ track|safe }}">{{ track|safe }}</a></span>
             {% if track.resource_broadcastaudio.size %}<span class="archive_dl_size"><div>{{ track.resource_broadcastaudio.size|filesizeformat }}</div></span>{% endif %}
         </div>
         {% endif %}

--- a/djangoplicity/templates/scripts/embedded_list.html
+++ b/djangoplicity/templates/scripts/embedded_list.html
@@ -5,8 +5,8 @@
     {% for object in object.videoscript_set.all %}
         {% if object.resource_script %}
         <div class="archive_download">
-            <span class="archive_dl_icon"><img src="{% static "icons/icon_doc.png" %}" /></span>
-            <span class="archive_dl_text"><a href="{{ object.resource_script.url }}"{{ object.resource_script.extra_attrs }}>{{ object|safe }}</a></span>
+            <span class="archive_dl_icon"><img src="{% static "icons/icon_doc.png" %}" alt="Document Icon"/></span>
+            <span class="archive_dl_text"><a href="{{ object.resource_script.url }}"{{ object.resource_script.extra_attrs }} aria-label="{{ object|safe }}">{{ object|safe }}</a></span>
             {% if object.resource_script.size %}<span class="archive_dl_size"><div>{{ object.resource_script.size|filesizeformat }}</div></span>{% endif %}
         </div>
         {% endif %}

--- a/djangoplicity/templates/subtitles/embedded_list.html
+++ b/djangoplicity/templates/subtitles/embedded_list.html
@@ -4,8 +4,8 @@
 {% for sub in object.get_ordered_subtitles %}
     {% if sub.resource_srt %}
     <div class="archive_download">
-        <span class="archive_dl_icon"><img src="{% static "icons/icon_txt.gif" %}" /></span>
-        <span class="archive_dl_text"><a href="{{ sub.resource_srt.url }}"{{sub.resource_srt.extra_attrs}}>{{sub|safe}}</a></span>
+        <span class="archive_dl_icon"><img src="{% static "icons/icon_txt.gif" %}" alt="txt Icon"/></span>
+        <span class="archive_dl_text"><a href="{{ sub.resource_srt.url }}"{{sub.resource_srt.extra_attrs}} aria-label="{{sub|safe}}">{{sub|safe}}</a></span>
         {% if sub.resource_srt.size %}<span class="archive_dl_size"><div>{{sub.resource_srt.size|filesizeformat}}</div></span>{% endif %}
     </div>
     {% endif %}


### PR DESCRIPTION
I have updated the templates that are used to display downloadable files such as scripts, broadcast audio, subtitles. Adding alt and aria-label attributes to "img" and "a" tags