### PR TITLE
Feature/Add meta description

### DIFF
--- a/djangoplicity/templates/archives/opengraph.html
+++ b/djangoplicity/templates/archives/opengraph.html
@@ -23,8 +23,10 @@
     {% endif %}
     {% if object.headline %}
         <meta property="og:description" content="{{ object.headline }}" />
+        <meta name="description" content="{{ object.headline }}" />
     {% elif object.title %}
         <meta property="og:description" content="{{ object.title }}" />
+        <meta name="description" content="{{ object.title }}" />
     {% endif %}
     {% if object.resource_medium_podcast %}
         <meta property="og:video:secure_url" content="{{ object.resource_medium_podcast.absolute_url }}" />


### PR DESCRIPTION
SiteImprove recommends including a Meta description tag. In the repository, there was a meta "og:description" tag that was effective for social media embedded links. I then added the "description" tag, which is the one that Siteimprove was looking for.