### PR TITLE
Feature/add filter for E&E category announcements

### DIFF
--- a/djangoplicity/announcements/api/v2/views.py
+++ b/djangoplicity/announcements/api/v2/views.py
@@ -39,12 +39,23 @@ class AnnouncementFilter(filters.FilterSet):
 
 class AnnouncementViewMixin:
     def get_queryset(self):
-        qs, query_data = AnnouncementOptions.Queries.default.queryset(
-            Announcement,
-            AnnouncementOptions,
-            self.request,
-            mode=self.request.GET.get('translation_mode', DEFAULT_API_TRANSLATION_MODE)
-        )
+        is_e_and_e = self.request.GET.get('is_e_and_e')
+        
+        if is_e_and_e and is_e_and_e.lower() == 'true':
+            qs, query_data = AnnouncementOptions.Queries.e_and_e.queryset(
+                Announcement,
+                AnnouncementOptions,
+                self.request,
+                mode=self.request.GET.get('translation_mode', DEFAULT_API_TRANSLATION_MODE)
+            )
+        else:
+            qs, query_data = AnnouncementOptions.Queries.default.queryset(
+                Announcement,
+                AnnouncementOptions,
+                self.request,
+                mode=self.request.GET.get('translation_mode', DEFAULT_API_TRANSLATION_MODE)
+            )
+
         return qs
 
 

--- a/djangoplicity/announcements/api/v2/views.py
+++ b/djangoplicity/announcements/api/v2/views.py
@@ -74,7 +74,8 @@ class AnnouncementViewMixin:
         OpenApiParameter(
             "is_e_and_e",
             OpenApiTypes.BOOL,
-            description="If you select “true”, you will receive the E&E category announcements."
+            description="If you select “true”, you will receive the E&E category announcements.",
+            default=False 
         ),
         OpenApiParameter(
             "page_size",

--- a/djangoplicity/announcements/api/v2/views.py
+++ b/djangoplicity/announcements/api/v2/views.py
@@ -21,10 +21,11 @@ class AnnouncementPagination(PageNumberPagination):
 class AnnouncementFilter(filters.FilterSet):
     program = filters.CharFilter(field_name="programs__url")
     search = filters.CharFilter(method='search_filter')
+    is_e_and_e = filters.BooleanFilter(field_name="is_e_and_e")
 
     class Meta:
         model = Announcement
-        fields = ['program']
+        fields = ['program','is_e_and_e']
 
     def search_filter(self, queryset, name, value):
         if value:
@@ -58,6 +59,11 @@ class AnnouncementViewMixin:
             "search",
             OpenApiTypes.STR,
             description="Search by title, subtitle, or description"
+        ),
+        OpenApiParameter(
+            "is_e_and_e",
+            OpenApiTypes.BOOL,
+            description="If you select “true”, you will receive the E&E category announcements."
         ),
         OpenApiParameter(
             "page_size",

--- a/djangoplicity/announcements/queries.py
+++ b/djangoplicity/announcements/queries.py
@@ -7,7 +7,6 @@ class AnnouncementsAllPublicQuery(AllPublicQuery):
     '''
     def queryset(self, model, options, request, **kwargs):
         (qs, query_data) = super(AnnouncementsAllPublicQuery, self).queryset(model, options, request, **kwargs)
-        qs = qs.filter(is_e_and_e=False)
         return (qs, query_data)
     
 

--- a/djangoplicity/announcements/queries.py
+++ b/djangoplicity/announcements/queries.py
@@ -7,6 +7,7 @@ class AnnouncementsAllPublicQuery(AllPublicQuery):
     '''
     def queryset(self, model, options, request, **kwargs):
         (qs, query_data) = super(AnnouncementsAllPublicQuery, self).queryset(model, options, request, **kwargs)
+        qs = qs.filter(is_e_and_e=False)
         return (qs, query_data)
     
 


### PR DESCRIPTION
I have added the is_e_and_e Boolean filter to allow filtering announcements in the E&E category. 

I also removed the default filter qs.filter(is_e_and_e=False) in queries.py, because it was not bringing the announcements marked as E&E in the API response when no filter was applied and when I applied the is_e_and_e filter with true, it was not bringing me any announcements.