### PR TITLE
Fix/resources URLs appending domain twice

### DIFF
--- a/djangoplicity/media/models/images.py
+++ b/djangoplicity/media/models/images.py
@@ -577,7 +577,11 @@ class Image( ArchiveModel, TranslationModel, ContentDeliveryModel, CropModel ):
     def resource_url(self, resource='original' ):
         try:
             if resource == 'original':
-                return "http://%s%s" % (get_current_site(None).domain, self.resource_original.url)
+                if not self.resource_original.url.startswith('http'):
+                    url = "http://%s%s" % (get_current_site(None).domain, self.resource_original.url)
+                else:
+                    url = self.resource_original.url
+                return url
             else:
                 attr = "resource_" % resource
                 if hasattr(self, attr):

--- a/djangoplicity/media/models/images.py
+++ b/djangoplicity/media/models/images.py
@@ -578,7 +578,7 @@ class Image( ArchiveModel, TranslationModel, ContentDeliveryModel, CropModel ):
         try:
             if resource == 'original':
                 if not self.resource_original.url.startswith('http'):
-                    url = "http://%s%s" % (get_current_site(None).domain, self.resource_original.url)
+                    url = "https://%s%s" % (get_current_site(None).domain, self.resource_original.url)
                 else:
                     url = self.resource_original.url
                 return url


### PR DESCRIPTION
Currently, when modifying the metadata content of an image, an error related to the AVMURL class is being generated. The value received by this class has the following incorrect format:

http://noirlab.eduhttps://noirlab-dev.s3.amazonaws.com/media/archives/images/original/test-avm1.tif

This error occurs because previously the images were stored locally, so the URL was constructed by concatenating the domain with the relative path of the file. However, now that the images are stored in AWS S3, the image.file.url field already contains a full URL, causing the concatenation to generate an invalid string.

To correct this behavior, the resource_url function was modified by adding a condition that checks if the path already contains http. If so, the URL is used directly without prefixing the domain.
