### PR TITLE
Feature/Fix TranslationForeignKey for deletion of images

### DIFF
--- a/djangoplicity/translation/fields.py
+++ b/djangoplicity/translation/fields.py
@@ -96,7 +96,7 @@ class TranslationForeignKey(ForeignKey):
         ForwardManyToOneDescriptor is replaced by TranslationForwardManyToOneDescriptor and
         only_sources passed as argument
         '''
-        super(RelatedField, self).contribute_to_class(cls, name, private_only=private_only, **kwargs)  # pylint: disable=E1003
+        super(TranslationForeignKey, self).contribute_to_class(cls, name, private_only=private_only, **kwargs)  # pylint: disable=E1003
 
         self.opts = cls._meta
 


### PR DESCRIPTION
The current implementation of TranslationForeignKey was incorrectly calling `super(RelatedField, self).contribute_to_class(...)`, which bypassed ForeignKey’s logic and caused some field parameters (such as `on_delete=models.CASCADE`) not to be properly registered.

As a result, PostgreSQL constraints were created with `ON DELETE RESTRICT` instead of `ON DELETE CASCADE`, preventing deletions from propagating as expected.

**After making this change, the schema constraints must be regenerated by manually altering the tables with SQL or by generating a new migration.**