### PR TITLE
feature/enforce rgb24 in ffmpeg to avoid green thumbnails

### DIFF
--- a/djangoplicity/media/tasks.py
+++ b/djangoplicity/media/tasks.py
@@ -816,7 +816,7 @@ def generate_thumbnail(app_label, model_name, pk, sendtask_callback=None, sendta
         if position == 'middle':
             position = int(v.duration_in_seconds() / 2)
 
-        cmd = 'ffmpeg -ss {position} -i {input} -vframes 1 -q:v 2 {output}'.format(position=position, input=path, output=output)
+        cmd = 'ffmpeg -ss {position} -i {input} -vframes 1 -q:v 2 -vf "format=rgb24" {output}'.format(position=position, input=path, output=output)
         if force_generation:
             cmd += ' -y' # To overwrite image
         else:


### PR DESCRIPTION
I have added -vf "format=rgb24" to the ffmpeg framegrab command.

I ran local tests. In the first test, I uploaded the video without making any changes to the code, and the thumbnail was indeed generated in green. I then added the -vf "format=rgb24" command and uploaded the same video again with a different ID, and the thumbnail was generated correctly.
<img width="1194" height="862" alt="Captura de pantalla 2025-09-26 105517" src="https://github.com/user-attachments/assets/37c0b2f0-c5bc-4434-a514-3b4ef51af7cc" />
<img width="1201" height="888" alt="Captura de pantalla 2025-09-26 105509" src="https://github.com/user-attachments/assets/f38bb962-08c5-4195-9152-85e177974afb" />


