### PR TITLE
Feature/Use new domain `media.gemini.edu` URL in the API responses for Gemini

### DIFF
--- a/djangoplicity/announcements/api/v2/serializers.py
+++ b/djangoplicity/announcements/api/v2/serializers.py
@@ -7,7 +7,7 @@ from djangoplicity.media.api.v2.serializers import ImageMiniSerializer, VideoMin
 from djangoplicity.metadata.api.v2.serializers import ProgramSerializer
 from djangoplicity.archives.api.v2.serializers import ArchiveSerializerMixin
 
-from djangoplicity.utils.domain_rewrite import has_gemini_program
+from djangoplicity.utils.domain_rewrite import has_gemini_program_request
 
 
 class AnnouncementMiniSerializer(ArchiveSerializerMixin, serializers.ModelSerializer):
@@ -32,7 +32,8 @@ class AnnouncementMiniSerializer(ArchiveSerializerMixin, serializers.ModelSerial
         images = related_archive_items(Announcement.related_images, obj)
         # By default, related_archive_items put 'main visual' images first, then we can simply return the first one
         if images:
-            has_gemini_program_flag = has_gemini_program(obj.programs.all())
+            request = self.context.get('request')
+            has_gemini_program_flag = has_gemini_program_request(request)
             context = {**self.context, 'has_gemini_program': has_gemini_program_flag}
 
             return ImageMiniSerializer(images[0], context=context).data
@@ -64,17 +65,9 @@ class AnnouncementSerializer(ArchiveSerializerMixin, serializers.ModelSerializer
     @extend_schema_field(ImageMiniSerializer(many=True))
     def get_images(self, obj):
         images = related_archive_items(Announcement.related_images, obj)
-
-        has_gemini_program_flag = has_gemini_program(obj.programs.all())
-        context = {**self.context, 'has_gemini_program': has_gemini_program_flag}
-        
-        return ImageMiniSerializer(images, many=True, context=context).data
+        return ImageMiniSerializer(images, many=True).data        
 
     @extend_schema_field(VideoMiniSerializer(many=True))
     def get_videos(self, obj):
         videos = related_archive_items(Announcement.related_videos, obj)
-
-        has_gemini_program_flag = has_gemini_program(obj.programs.all())
-        context = {**self.context, 'has_gemini_program': has_gemini_program_flag}
-
-        return VideoMiniSerializer(videos, many=True, context=context).data
+        return VideoMiniSerializer(videos, many=True).data

--- a/djangoplicity/announcements/api/v2/serializers.py
+++ b/djangoplicity/announcements/api/v2/serializers.py
@@ -7,6 +7,8 @@ from djangoplicity.media.api.v2.serializers import ImageMiniSerializer, VideoMin
 from djangoplicity.metadata.api.v2.serializers import ProgramSerializer
 from djangoplicity.archives.api.v2.serializers import ArchiveSerializerMixin
 
+from djangoplicity.utils.domain_rewrite import has_gemini_program
+
 
 class AnnouncementMiniSerializer(ArchiveSerializerMixin, serializers.ModelSerializer):
     main_image = serializers.SerializerMethodField()
@@ -30,7 +32,10 @@ class AnnouncementMiniSerializer(ArchiveSerializerMixin, serializers.ModelSerial
         images = related_archive_items(Announcement.related_images, obj)
         # By default, related_archive_items put 'main visual' images first, then we can simply return the first one
         if images:
-            return ImageMiniSerializer(images[0]).data
+            has_gemini_program_flag = has_gemini_program(obj.programs.all())
+            context = {**self.context, 'has_gemini_program': has_gemini_program_flag}
+
+            return ImageMiniSerializer(images[0], context=context).data
 
 
 class AnnouncementSerializer(ArchiveSerializerMixin, serializers.ModelSerializer):
@@ -59,9 +64,17 @@ class AnnouncementSerializer(ArchiveSerializerMixin, serializers.ModelSerializer
     @extend_schema_field(ImageMiniSerializer(many=True))
     def get_images(self, obj):
         images = related_archive_items(Announcement.related_images, obj)
-        return ImageMiniSerializer(images, many=True).data
+
+        has_gemini_program_flag = has_gemini_program(obj.programs.all())
+        context = {**self.context, 'has_gemini_program': has_gemini_program_flag}
+        
+        return ImageMiniSerializer(images, many=True, context=context).data
 
     @extend_schema_field(VideoMiniSerializer(many=True))
     def get_videos(self, obj):
         videos = related_archive_items(Announcement.related_videos, obj)
-        return VideoMiniSerializer(videos, many=True).data
+
+        has_gemini_program_flag = has_gemini_program(obj.programs.all())
+        context = {**self.context, 'has_gemini_program': has_gemini_program_flag}
+
+        return VideoMiniSerializer(videos, many=True, context=context).data

--- a/djangoplicity/media/api/v2/serializers.py
+++ b/djangoplicity/media/api/v2/serializers.py
@@ -11,7 +11,7 @@ from djangoplicity.archives.api.v2.serializers import ArchiveSerializerMixin
 from djangoplicity.metadata.api.v2.serializers import CategorySerializer
 from .typings import ImageFormatsURLs, VideoFormatsURLs
 
-from djangoplicity.utils.domain_rewrite import has_gemini_category, replace_gemini_domains
+from djangoplicity.utils.domain_rewrite import replace_gemini_domains, has_gemini_category_request
 
 
 IMAGE__TINY_FORMATS = ['thumb300y', 'screen', 'thumb700x']
@@ -46,19 +46,19 @@ class ImageMiniSerializer(ImageSerializerMixin, serializers.ModelSerializer):
         data = super().to_representation(instance)
         
         context = self.context or {}
-
-        if context.get('has_gemini_program') or has_gemini_category(data.get('categories', [])):
+        request = context.get('request')
+        
+        if context.get('has_gemini_program') or has_gemini_category_request(request):
             data = replace_gemini_domains(data)
         
         return data
 
 class ImageTinySerializer(ArchiveSerializerMixin, serializers.ModelSerializer):
     formats = serializers.SerializerMethodField()
-    categories = CategorySerializer(many=True, source='web_category')
 
     class Meta:
         model = Image
-        fields = ['id', 'url', 'lang', 'source', 'title', 'width', 'height', 'categories', 'formats']
+        fields = ['id', 'url', 'lang', 'source', 'title', 'width', 'height', 'formats']
 
     def get_formats(self, obj) -> ImageTinyFormatsURLs:
         return get_all_instance_archives_urls(obj, IMAGE__TINY_FORMATS)
@@ -66,11 +66,11 @@ class ImageTinySerializer(ArchiveSerializerMixin, serializers.ModelSerializer):
     def to_representation(self, instance):
         data = super().to_representation(instance)
 
-        if has_gemini_category(data.get('categories', [])):
-            data = replace_gemini_domains(data)
+        context = self.context or {}
+        request = context.get('request')
 
-        # Remove categories from tiny serializer output
-        data.pop('categories', None)
+        if has_gemini_category_request(request):
+            data = replace_gemini_domains(data)
 
         return data
 
@@ -88,18 +88,7 @@ class ImageSerializer(ImageSerializerMixin, serializers.ModelSerializer):
 
     def get_resources(self, obj) -> List[ArchiveResource]:
         return get_instance_resources(obj)
-    
 
-    def to_representation(self, instance):
-        data = super().to_representation(instance)
-
-        context = self.context or {}
-
-        if context.get('has_gemini_program') or has_gemini_category(data.get('categories', [])):
-            data = replace_gemini_domains(data)
-        
-        return data
-    
 
 class VideoMiniSerializer(VideoSerializerMixin, serializers.ModelSerializer):
     class Meta:
@@ -114,8 +103,9 @@ class VideoMiniSerializer(VideoSerializerMixin, serializers.ModelSerializer):
         data = super().to_representation(instance)
 
         context = self.context or {}
+        request = context.get('request')
 
-        if context.get('has_gemini_program') or has_gemini_category(data.get('categories', [])):
+        if has_gemini_category_request(request):
             data = replace_gemini_domains(data)
 
         return data
@@ -127,14 +117,3 @@ class VideoSerializer(VideoSerializerMixin, serializers.ModelSerializer):
             'id', 'url', 'lang', 'source', 'title', 'headline', 'description', 'categories', 'type', 'credit',
             'release_date', 'featured', 'duration', 'youtube_video_id', 'use_youtube', 'formats'
         ]
-
-
-    def to_representation(self, instance):
-        data = super().to_representation(instance)
-
-        context = self.context or {}
-
-        if context.get('has_gemini_program') or has_gemini_category(data.get('categories', [])):
-            data = replace_gemini_domains(data)
-
-        return data

--- a/djangoplicity/media/api/v2/serializers.py
+++ b/djangoplicity/media/api/v2/serializers.py
@@ -11,6 +11,8 @@ from djangoplicity.archives.api.v2.serializers import ArchiveSerializerMixin
 from djangoplicity.metadata.api.v2.serializers import CategorySerializer
 from .typings import ImageFormatsURLs, VideoFormatsURLs
 
+from djangoplicity.utils.domain_rewrite import has_gemini_category, replace_gemini_domains
+
 
 IMAGE__TINY_FORMATS = ['thumb300y', 'screen', 'thumb700x']
 ImageTinyFormatsURLs = TypedDict('ImageFormatsURLs', dict(map(lambda x: (x, Optional[str]), IMAGE__TINY_FORMATS)))
@@ -39,17 +41,38 @@ class ImageMiniSerializer(ImageSerializerMixin, serializers.ModelSerializer):
     class Meta:
         model = Image
         fields = ['id', 'url', 'lang', 'source', 'title', 'width', 'height', 'featured', 'categories', 'formats']
+    
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
         
+        context = self.context or {}
+
+        if context.get('has_gemini_program') or has_gemini_category(data.get('categories', [])):
+            data = replace_gemini_domains(data)
         
+        return data
+
 class ImageTinySerializer(ArchiveSerializerMixin, serializers.ModelSerializer):
     formats = serializers.SerializerMethodField()
+    categories = CategorySerializer(many=True, source='web_category')
 
     class Meta:
         model = Image
-        fields = ['id', 'url', 'lang', 'source', 'title', 'width', 'height', 'formats']
+        fields = ['id', 'url', 'lang', 'source', 'title', 'width', 'height', 'categories', 'formats']
 
     def get_formats(self, obj) -> ImageTinyFormatsURLs:
         return get_all_instance_archives_urls(obj, IMAGE__TINY_FORMATS)
+    
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+
+        if has_gemini_category(data.get('categories', [])):
+            data = replace_gemini_domains(data)
+
+        # Remove categories from tiny serializer output
+        data.pop('categories', None)
+
+        return data
 
 
 class ImageSerializer(ImageSerializerMixin, serializers.ModelSerializer):
@@ -65,7 +88,18 @@ class ImageSerializer(ImageSerializerMixin, serializers.ModelSerializer):
 
     def get_resources(self, obj) -> List[ArchiveResource]:
         return get_instance_resources(obj)
+    
 
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+
+        context = self.context or {}
+
+        if context.get('has_gemini_program') or has_gemini_category(data.get('categories', [])):
+            data = replace_gemini_domains(data)
+        
+        return data
+    
 
 class VideoMiniSerializer(VideoSerializerMixin, serializers.ModelSerializer):
     class Meta:
@@ -76,6 +110,16 @@ class VideoMiniSerializer(VideoSerializerMixin, serializers.ModelSerializer):
         ]
 
 
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+
+        context = self.context or {}
+
+        if context.get('has_gemini_program') or has_gemini_category(data.get('categories', [])):
+            data = replace_gemini_domains(data)
+
+        return data
+
 class VideoSerializer(VideoSerializerMixin, serializers.ModelSerializer):
     class Meta:
         model = Video
@@ -83,3 +127,14 @@ class VideoSerializer(VideoSerializerMixin, serializers.ModelSerializer):
             'id', 'url', 'lang', 'source', 'title', 'headline', 'description', 'categories', 'type', 'credit',
             'release_date', 'featured', 'duration', 'youtube_video_id', 'use_youtube', 'formats'
         ]
+
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+
+        context = self.context or {}
+
+        if context.get('has_gemini_program') or has_gemini_category(data.get('categories', [])):
+            data = replace_gemini_domains(data)
+
+        return data

--- a/djangoplicity/releases/api/v2/serializers.py
+++ b/djangoplicity/releases/api/v2/serializers.py
@@ -7,6 +7,8 @@ from djangoplicity.media.api.v2.serializers import ImageMiniSerializer, VideoMin
 from djangoplicity.metadata.api.v2.serializers import ProgramSerializer
 from djangoplicity.archives.api.v2.serializers import ArchiveSerializerMixin
 
+from djangoplicity.utils.domain_rewrite import has_gemini_program
+
 
 class ReleaseSerializerMixin(ArchiveSerializerMixin):
     release_type = serializers.StringRelatedField()
@@ -45,7 +47,10 @@ class ReleaseMiniSerializer(ReleaseSerializerMixin, serializers.ModelSerializer)
         images = related_archive_items(Release.related_images, obj)
         # By default, related_archive_items put 'main visual' images first, then we can simply return the first one
         if images:
-            return ImageMiniSerializer(images[0]).data
+            has_gemini_program_flag = has_gemini_program(obj.programs.all())
+            context = {**self.context, 'has_gemini_program': has_gemini_program_flag}
+
+            return ImageMiniSerializer(images[0], context=context).data
 
 
 class ReleaseSerializer(ReleaseSerializerMixin, serializers.ModelSerializer):
@@ -64,9 +69,17 @@ class ReleaseSerializer(ReleaseSerializerMixin, serializers.ModelSerializer):
     @extend_schema_field(ImageMiniSerializer(many=True))
     def get_images(self, obj):
         images = related_archive_items(Release.related_images, obj)
-        return ImageMiniSerializer(images, many=True).data
+
+        has_gemini_program_flag = has_gemini_program(obj.programs.all())
+        context = {**self.context, 'has_gemini_program': has_gemini_program_flag}
+        
+        return ImageMiniSerializer(images, many=True, context=context).data
 
     @extend_schema_field(VideoMiniSerializer(many=True))
     def get_videos(self, obj):
         videos = related_archive_items(Release.related_videos, obj)
-        return VideoMiniSerializer(videos, many=True).data
+
+        has_gemini_program_flag = has_gemini_program(obj.programs.all())
+        context = {**self.context, 'has_gemini_program': has_gemini_program_flag}
+
+        return VideoMiniSerializer(videos, many=True, context=context).data

--- a/djangoplicity/releases/api/v2/serializers.py
+++ b/djangoplicity/releases/api/v2/serializers.py
@@ -7,7 +7,7 @@ from djangoplicity.media.api.v2.serializers import ImageMiniSerializer, VideoMin
 from djangoplicity.metadata.api.v2.serializers import ProgramSerializer
 from djangoplicity.archives.api.v2.serializers import ArchiveSerializerMixin
 
-from djangoplicity.utils.domain_rewrite import has_gemini_program
+from djangoplicity.utils.domain_rewrite import has_gemini_program_request
 
 
 class ReleaseSerializerMixin(ArchiveSerializerMixin):
@@ -47,7 +47,9 @@ class ReleaseMiniSerializer(ReleaseSerializerMixin, serializers.ModelSerializer)
         images = related_archive_items(Release.related_images, obj)
         # By default, related_archive_items put 'main visual' images first, then we can simply return the first one
         if images:
-            has_gemini_program_flag = has_gemini_program(obj.programs.all())
+            request = self.context.get('request')
+
+            has_gemini_program_flag = has_gemini_program_request(request)
             context = {**self.context, 'has_gemini_program': has_gemini_program_flag}
 
             return ImageMiniSerializer(images[0], context=context).data
@@ -69,17 +71,9 @@ class ReleaseSerializer(ReleaseSerializerMixin, serializers.ModelSerializer):
     @extend_schema_field(ImageMiniSerializer(many=True))
     def get_images(self, obj):
         images = related_archive_items(Release.related_images, obj)
-
-        has_gemini_program_flag = has_gemini_program(obj.programs.all())
-        context = {**self.context, 'has_gemini_program': has_gemini_program_flag}
-        
-        return ImageMiniSerializer(images, many=True, context=context).data
+        return ImageMiniSerializer(images, many=True).data
 
     @extend_schema_field(VideoMiniSerializer(many=True))
     def get_videos(self, obj):
         videos = related_archive_items(Release.related_videos, obj)
-
-        has_gemini_program_flag = has_gemini_program(obj.programs.all())
-        context = {**self.context, 'has_gemini_program': has_gemini_program_flag}
-
-        return VideoMiniSerializer(videos, many=True, context=context).data
+        return VideoMiniSerializer(videos, many=True).data

--- a/djangoplicity/utils/domain_rewrite.py
+++ b/djangoplicity/utils/domain_rewrite.py
@@ -15,7 +15,7 @@ def replace_storage_domain(url: str, program: str):
         return url 
 
     if program == GEMINI_SLUG:
-        url = url.replace(TEST_DOMAIN, GEMINI_DOMAIN)
+        url = url.replace(DEFAULT_STORAGE_DOMAIN, GEMINI_DOMAIN)
         return url
     
     return url

--- a/djangoplicity/utils/domain_rewrite.py
+++ b/djangoplicity/utils/domain_rewrite.py
@@ -1,0 +1,57 @@
+from typing import Dict, List, Any
+
+GEMINI_SLUG = 'gemini' # The slug used for the Gemini program and category
+GEMINI_DOMAIN = 'media.gemini.edu'
+DEFAULT_STORAGE_DOMAIN = 'storage.noirlab.edu'
+TEST_DOMAIN = 'localhost:8000/public'
+
+
+def replace_storage_domain(url: str, program: str):
+    """
+        Reeplace the domain 'storage.noirlab.edu' to 'media.gemini.edu'
+        when the program is gemini. Used for img and video.
+    """
+    if not url:
+        return url 
+
+    if program == GEMINI_SLUG:
+        url = url.replace(TEST_DOMAIN, GEMINI_DOMAIN)
+        return url
+    
+    return url
+
+
+def has_gemini_category(categories: List[Dict[str, Any]]) -> bool:
+    """Return True if any category dict has slug 'gemini'."""
+    return any(
+        cat.get("slug", "").lower() == GEMINI_SLUG 
+        for cat in (categories or [])
+    )
+
+
+def has_gemini_program(programs) -> bool:
+    """Return True if any related program has slug 'gemini'."""
+    return any(
+        getattr(p, "url", "").lower() == GEMINI_SLUG 
+        for p in programs
+    )
+
+def replace_gemini_domains(data: Dict[str, Any], key: str = GEMINI_SLUG) -> Dict[str, Any]:
+    """
+    Replace domains inside `formats` and `resources` fields if present.
+    This is used by Image and Video serializers.
+    """
+    # Replace in formats
+    if isinstance(data.get("formats"), dict):
+        data["formats"] = {
+            fmt: replace_storage_domain(url, key)
+            for fmt, url in data["formats"].items()
+        }
+
+    # Replace in resources (for ImageSerializer)
+    if isinstance(data.get("resources"), list):
+        for res in data["resources"]:
+            if "URL" in res:
+                res["URL"] = replace_storage_domain(res["URL"], key)
+
+    return data

--- a/djangoplicity/utils/domain_rewrite.py
+++ b/djangoplicity/utils/domain_rewrite.py
@@ -21,20 +21,29 @@ def replace_storage_domain(url: str, program: str):
     return url
 
 
-def has_gemini_category(categories: List[Dict[str, Any]]) -> bool:
-    """Return True if any category dict has slug 'gemini'."""
-    return any(
-        cat.get("slug", "").lower() == GEMINI_SLUG 
-        for cat in (categories or [])
-    )
+def has_gemini_category_request(request) -> bool:
+    """
+    Return True if the request query parameter `category` equals 'gemini'.
+    """
+
+    if not request:
+        return False
+
+    category_param = request.query_params.get('category')
+    return isinstance(category_param, str) and category_param.lower() == GEMINI_SLUG
 
 
-def has_gemini_program(programs) -> bool:
-    """Return True if any related program has slug 'gemini'."""
-    return any(
-        getattr(p, "url", "").lower() == GEMINI_SLUG 
-        for p in programs
-    )
+def has_gemini_program_request(request) -> bool:
+    """
+    Return True if the request query parameter `program` equals 'gemini'.
+    Handles missing request or missing query_params gracefully.
+    """
+    if not request:
+        return False
+
+    program_param = request.query_params.get('program')
+    return isinstance(program_param, str) and program_param.lower() == GEMINI_SLUG
+
 
 def replace_gemini_domains(data: Dict[str, Any], key: str = GEMINI_SLUG) -> Dict[str, Any]:
     """


### PR DESCRIPTION
### Description  
This PR updates the logic for domain replacement in the following endpoints:  

- **announcements**  
- **releases**  
- **media/images**  
- **media/videos**

---

### Objective  
When a program or category has the slug **"gemini"**, all related URLs are now replaced with the correct Gemini domain.

---

###  Solution  
A new **utils** file was created to handle the replacement logic in a clean and reusable way.  
It also includes small helper methods to check:  
- if an item has a Gemini program (by checking the program URLs list), or  
- if it has a Gemini category (by checking each category slug).  

> **Note:** Some announcements, releases, or images can have multiple programs or categories.  
> In those cases, if at least one of them belongs to Gemini, the replacement will be applied.

The serializers were updated to use this helper inside the **`to_representation`** method, where the replacement logic is executed.  
In some cases, the **serializer context** is also used to detect whether the related program or category belongs to Gemini.

---

### Test in Local
To test in local I added a varaible `TEST_DOMAIN = 'localhost:8000/public'`
And then, if the images for example has the category Gemini, rewrite the domain

For example when has category Gemini in Image
<img width="754" height="537" alt="image" src="https://github.com/user-attachments/assets/98c0e0c9-2695-4aa7-aea8-db4084d55b32" />

For example when has not category Gemini
<img width="817" height="414" alt="image" src="https://github.com/user-attachments/assets/aea2305b-a0d4-4a60-9fd7-73b407d6436e" />

