### PR TITLE
Feature/Ticket #CEE-4304 Improve performance in dynamic press release and announcement searches using caching

### DIFF
--- a/djangoplicity/announcements/api/v2/serializers.py
+++ b/djangoplicity/announcements/api/v2/serializers.py
@@ -31,26 +31,25 @@ class AnnouncementMiniSerializer(ArchiveSerializerMixin, serializers.ModelSerial
 
     @extend_schema_field(ImageMiniSerializer())
     def get_main_image(self, obj):
-        cache_key = f"announcement_main_image_{obj.id}"
+        request = self.context.get('request')
+        has_gemini_program_flag = has_gemini_program_request(request)
+
+        suffix = 'gemini' if has_gemini_program_flag else 'default'
+        cache_key = f"announcement_main_image_{obj.id}_{suffix}"
         cache_timeout = getattr(settings, 'ANNOUNCEMENTS_CACHE_TIMEOUT', 60 * 60 * 2) # 2 hours
 
         cached = cache.get(cache_key)
-
         if cached is not None:
             return cached
 
         images = related_archive_items(Announcement.related_images, obj)
-
         if not images:
             cache.set(cache_key, None, timeout=cache_timeout) 
             return None
 
         # By default, related_archive_items put 'main visual' images first, then we can simply return the first one
 
-        request = self.context.get('request')
-        has_gemini_program_flag = has_gemini_program_request(request)
         context = {**self.context, 'has_gemini_program': has_gemini_program_flag}
-
         data = ImageMiniSerializer(images[0], context=context).data
 
         cache.set(cache_key, data, timeout=cache_timeout)

--- a/djangoplicity/announcements/api/v2/serializers.py
+++ b/djangoplicity/announcements/api/v2/serializers.py
@@ -7,6 +7,9 @@ from djangoplicity.media.api.v2.serializers import ImageMiniSerializer, VideoMin
 from djangoplicity.metadata.api.v2.serializers import ProgramSerializer
 from djangoplicity.archives.api.v2.serializers import ArchiveSerializerMixin
 
+from django.core.cache import cache
+
+from django.conf import settings
 
 class AnnouncementMiniSerializer(ArchiveSerializerMixin, serializers.ModelSerializer):
     main_image = serializers.SerializerMethodField()
@@ -27,10 +30,25 @@ class AnnouncementMiniSerializer(ArchiveSerializerMixin, serializers.ModelSerial
 
     @extend_schema_field(ImageMiniSerializer())
     def get_main_image(self, obj):
+        cache_key = f"announcement_main_image_{obj.id}"
+        cache_timeout = getattr(settings, 'ANNOUNCEMENTS_CACHE_TIMEOUT', 60 * 60 * 2) # 2 hours
+
+        cached = cache.get(cache_key)
+
+        if cached is not None:
+            return cached
+
         images = related_archive_items(Announcement.related_images, obj)
+
+        if not images:
+            cache.set(cache_key, None, timeout=cache_timeout) 
+            return None
+
         # By default, related_archive_items put 'main visual' images first, then we can simply return the first one
-        if images:
-            return ImageMiniSerializer(images[0]).data
+        data = ImageMiniSerializer(images[0]).data
+
+        cache.set(cache_key, data, timeout=cache_timeout)
+        return data
 
 
 class AnnouncementSerializer(ArchiveSerializerMixin, serializers.ModelSerializer):

--- a/djangoplicity/announcements/api/v2/views.py
+++ b/djangoplicity/announcements/api/v2/views.py
@@ -56,6 +56,8 @@ class AnnouncementViewMixin:
                 mode=self.request.GET.get('translation_mode', DEFAULT_API_TRANSLATION_MODE)
             )
 
+        qs = qs.select_related('announcement_type').prefetch_related('programs')
+
         return qs
 
 

--- a/djangoplicity/releases/api/v2/serializers.py
+++ b/djangoplicity/releases/api/v2/serializers.py
@@ -46,27 +46,28 @@ class ReleaseMiniSerializer(ReleaseSerializerMixin, serializers.ModelSerializer)
 
     @extend_schema_field(ImageMiniSerializer)
     def get_main_image(self, obj):
-        cache_key = f"release_main_image_{obj.id}"
+        request = self.context.get('request')
+        has_gemini_program_flag = has_gemini_program_request(request)
+
+        suffix = 'gemini' if has_gemini_program_flag else 'default'
+        cache_key = f"release_main_image_{obj.id}_{suffix}"
         cache_timeout = getattr(settings, 'RELEASES_CACHE_TIMEOUT', 60 * 60 * 2) # 2 hours
 
         cached = cache.get(cache_key)
-
         if cached is not None:
             return cached
 
         images = related_archive_items(Release.related_images, obj)
+        if not images:
+            cache.set(cache_key, None, timeout=cache_timeout) 
+            return None
+        
         # By default, related_archive_items put 'main visual' images first, then we can simply return the first one
-        if images:
-            request = self.context.get('request')
-            has_gemini_program_flag = has_gemini_program_request(request)
-            context = {**self.context, 'has_gemini_program': has_gemini_program_flag}
-
-            data = ImageMiniSerializer(images[0], context=context).data
-            cache.set(cache_key, data, timeout=cache_timeout)
-            return data
-
-        cache.set(cache_key, None, timeout=cache_timeout) 
-        return None
+        context = {**self.context, 'has_gemini_program': has_gemini_program_flag}
+        data = ImageMiniSerializer(images[0], context=context).data
+        
+        cache.set(cache_key, data, timeout=cache_timeout)
+        return data
 
 
 class ReleaseSerializer(ReleaseSerializerMixin, serializers.ModelSerializer):

--- a/djangoplicity/releases/api/v2/serializers.py
+++ b/djangoplicity/releases/api/v2/serializers.py
@@ -7,6 +7,8 @@ from djangoplicity.media.api.v2.serializers import ImageMiniSerializer, VideoMin
 from djangoplicity.metadata.api.v2.serializers import ProgramSerializer
 from djangoplicity.archives.api.v2.serializers import ArchiveSerializerMixin
 
+from django.core.cache import cache
+from django.conf import settings
 
 class ReleaseSerializerMixin(ArchiveSerializerMixin):
     release_type = serializers.StringRelatedField()
@@ -42,10 +44,23 @@ class ReleaseMiniSerializer(ReleaseSerializerMixin, serializers.ModelSerializer)
 
     @extend_schema_field(ImageMiniSerializer)
     def get_main_image(self, obj):
+        cache_key = f"release_main_image_{obj.id}"
+        cache_timeout = getattr(settings, 'RELEASES_CACHE_TIMEOUT', 60 * 60 * 2) # 2 hours
+
+        cached = cache.get(cache_key)
+
+        if cached is not None:
+            return cached
+
         images = related_archive_items(Release.related_images, obj)
         # By default, related_archive_items put 'main visual' images first, then we can simply return the first one
         if images:
-            return ImageMiniSerializer(images[0]).data
+            data = ImageMiniSerializer(images[0]).data
+            cache.set(cache_key, data, timeout=cache_timeout)
+            return data
+
+        cache.set(cache_key, None, timeout=cache_timeout) 
+        return None
 
 
 class ReleaseSerializer(ReleaseSerializerMixin, serializers.ModelSerializer):

--- a/djangoplicity/releases/api/v2/views.py
+++ b/djangoplicity/releases/api/v2/views.py
@@ -71,6 +71,20 @@ class ReleaseViewMixin:
             self.request,
             mode=self.request.GET.get('translation_mode', DEFAULT_API_TRANSLATION_MODE)
         )
+
+        qs = qs.select_related(
+            'release_type',
+            'kids_image',
+        ).prefetch_related(
+            'programs',
+            'subject_category',
+            'subject_name',
+            'facility',
+            'releasecontact_set',
+            'related_images',
+            'related_videos',
+            'stock_images'
+        )
         return qs
     
     def get_permissions(self):


### PR DESCRIPTION
## Description of Ticket #CEE-4304: Gemini: Dev: dynamic press release and announcement feed searches very slow

The dynamic press release and announcement feed searches on [gemini.edu](http://gemini.edu/) are very slow, some request has a duration approximately of 6-7 seconds. Try in:
- https://gemini.edu/news/press-releases?search=ERA
- https://gemini.edu/news/announcements?search=ERA

## Solutions:

In the list endpoints of `announcements/api/v2/views.py` and `releases/api/v2/views.py`, I added `select_related` and `prefetch_related` to reduce the N+1 query problem.

But this was not enough, because both `AnnouncementMiniSerializer` and `ReleaseMiniSerializer` still make extra queries when getting the main_image using the related_archive_items method. This method is optimized, but it still makes the request slow.

To fix this, I used the Memcached cache system that already exists in production. Now the main_image is saved in cache, so only the first request takes around 7 seconds. After that, the next requests are much faster because they use the cached data.

The cache timeout is set to `2 hours`, to keep a good balance between speed and data freshness.

## Example of results in Announcements
Without cache
Total queries: 151 (Time: 1.118 s)

With cache:
Total queries: 4 (Time: 0.217 s)

