### PR TITLE
Fix/use get_fieldsets instead of get_form to customize the admin based on request.user

### DIFF
--- a/djangoplicity/pages/admin.py
+++ b/djangoplicity/pages/admin.py
@@ -91,6 +91,9 @@ class PageAdmin( dpadmin.DjangoplicityModelAdmin, dpadmin.CleanHTMLAdmin, SyncTr
                 obj.groups.add(pagegroup)
 
     def get_fieldsets(self, request, obj=None):
+        '''
+        Only superusers can add/remove pages from/to groups
+        '''
         fieldsets = super(PageAdmin, self).get_fieldsets(request, obj)
         groups_fieldset = ('Groups', {'classes': ['collapse'], 'fields': ('groups', )})
 

--- a/djangoplicity/pages/admin.py
+++ b/djangoplicity/pages/admin.py
@@ -90,19 +90,17 @@ class PageAdmin( dpadmin.DjangoplicityModelAdmin, dpadmin.CleanHTMLAdmin, SyncTr
             else:
                 obj.groups.add(pagegroup)
 
-    def get_form(self, request, obj=None, **kwargs):
-        '''
-        Only superusers can add/remove pages from/to groups
-        '''
+    def get_fieldsets(self, request, obj=None):
+        fieldsets = super(PageAdmin, self).get_fieldsets(request, obj)
         groups_fieldset = ('Groups', {'classes': ['collapse'], 'fields': ('groups', )})
 
         if request.user.is_superuser:
-            if groups_fieldset not in self.fieldsets:
-                self.fieldsets.append(groups_fieldset)
-        elif groups_fieldset in self.fieldsets:
-            self.fieldsets.remove(groups_fieldset)
+            if groups_fieldset not in fieldsets:
+                fieldsets.append(groups_fieldset)
+        elif groups_fieldset in fieldsets:
+            fieldsets.remove(groups_fieldset)
 
-        return super(PageAdmin, self).get_form(request, obj, **kwargs)
+        return fieldsets
 
     def _get_user_page_groups(self, request):
         '''


### PR DESCRIPTION
# Ticket CEE-5719: Error Server 500 in page modules.

The way to recreate in development happen when I rebuild the Docker container or when I stop and restart it. The inconsistent behavior is related to the `get_form` method in `PageAdmin`, where the `self.fieldsets` attribute is directly modified.

Since `fieldsets` is a class attribute, this modification persists across requests and affects all users. This causes the `Groups` fieldset to be unavailable on the first load if the user is not an administrator, generating errors such as the missing `groups` key. After reloading the page, the instance is in a "fixed" state, so it appears to work again.

Upon reviewing the code, I noticed that a `get_fieldsets` method already exists, which is Django's recommended way to build fieldsets safely and dynamically based on context, without modifying the admin's global state.

Migrating the logic to the `get_fieldsets` method resolves the problem, and the missing `groups` key error no longer occurs.