### PR TITLE
Feature/Improve performance in Announcement and Releases Endpoints

### DIFF
--- a/djangoplicity/announcements/api/v2/serializers.py
+++ b/djangoplicity/announcements/api/v2/serializers.py
@@ -3,7 +3,7 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from djangoplicity.archives.utils import related_archive_items
 
-from djangoplicity.media.api.v2.serializers import ImageMiniSerializer, VideoMiniSerializer
+from djangoplicity.media.api.v2.serializers import ImageMiniSerializer, VideoMiniSerializer, ImageTinySerializer
 from djangoplicity.metadata.api.v2.serializers import ProgramSerializer
 from djangoplicity.archives.api.v2.serializers import ArchiveSerializerMixin
 
@@ -33,27 +33,21 @@ class AnnouncementMiniSerializer(ArchiveSerializerMixin, serializers.ModelSerial
     def get_main_image(self, obj):
         request = self.context.get('request')
         has_gemini_program_flag = has_gemini_program_request(request)
-
-        suffix = 'gemini' if has_gemini_program_flag else 'default'
-        cache_key = f"announcement_main_image_{obj.id}_{suffix}"
-        cache_timeout = getattr(settings, 'ANNOUNCEMENTS_CACHE_TIMEOUT', 60 * 60 * 2) # 2 hours
-
-        cached = cache.get(cache_key)
-        if cached is not None:
-            return cached
-
-        images = related_archive_items(Announcement.related_images, obj)
-        if not images:
-            cache.set(cache_key, None, timeout=cache_timeout) 
-            return None
-
-        # By default, related_archive_items put 'main visual' images first, then we can simply return the first one
+        has_tiny_param = request and request.query_params.get('tiny') == 'true'
 
         context = {**self.context, 'has_gemini_program': has_gemini_program_flag}
-        data = ImageMiniSerializer(images[0], context=context).data
+        serializer_class = ImageTinySerializer if has_tiny_param else ImageMiniSerializer
 
-        cache.set(cache_key, data, timeout=cache_timeout)
-        return data
+        if hasattr(obj, '_main_image_cache'):
+            main_image = obj._main_image_cache
+        else:
+            images = related_archive_items(Announcement.related_images, obj)
+            main_image = images[0] if images else None
+        
+        if not main_image:
+            return None
+        
+        return serializer_class(main_image, context=context).data
 
 
 class AnnouncementSerializer(ArchiveSerializerMixin, serializers.ModelSerializer):

--- a/djangoplicity/announcements/api/v2/views.py
+++ b/djangoplicity/announcements/api/v2/views.py
@@ -84,6 +84,11 @@ class AnnouncementViewMixin:
             OpenApiTypes.INT,
             description=f"Number of results to return per page. Max: {AnnouncementPagination.max_page_size}, Default: {AnnouncementPagination.page_size}"
         ),
+        OpenApiParameter(
+            "tiny",
+            OpenApiTypes.BOOL,
+            description="If true returns a simplified response for the main image with minimal fields and few formats. Default: false"
+        )
     ],
 )
 class AnnouncementListView(mixins.ListModelMixin, AnnouncementViewMixin, TranslationAPIViewMixin, GenericViewSet):
@@ -93,6 +98,20 @@ class AnnouncementListView(mixins.ListModelMixin, AnnouncementViewMixin, Transla
     pagination_class = AnnouncementPagination
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = AnnouncementFilter
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+
+        # Pre-fetch main visuals for better performance
+        Announcement.store_main_visuals(queryset)
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
 
 
 class AnnouncementDetailView(mixins.RetrieveModelMixin, AnnouncementViewMixin, TranslationAPIViewMixin, GenericViewSet):

--- a/djangoplicity/media/api/v2/serializers.py
+++ b/djangoplicity/media/api/v2/serializers.py
@@ -14,7 +14,7 @@ from .typings import ImageFormatsURLs, VideoFormatsURLs
 from djangoplicity.utils.domain_rewrite import replace_gemini_domains, has_gemini_category_request
 
 
-IMAGE__TINY_FORMATS = ['thumb300y', 'screen', 'thumb700x']
+IMAGE__TINY_FORMATS = ['thumb300y', 'screen', 'thumb700x', 'thumb350x']
 ImageTinyFormatsURLs = TypedDict('ImageFormatsURLs', dict(map(lambda x: (x, Optional[str]), IMAGE__TINY_FORMATS)))
 
 class ImageSerializerMixin(ArchiveSerializerMixin):

--- a/djangoplicity/releases/api/v2/serializers.py
+++ b/djangoplicity/releases/api/v2/serializers.py
@@ -3,7 +3,7 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from djangoplicity.archives.utils import related_archive_items, get_all_instance_archives_urls
 
-from djangoplicity.media.api.v2.serializers import ImageMiniSerializer, VideoMiniSerializer
+from djangoplicity.media.api.v2.serializers import ImageMiniSerializer, VideoMiniSerializer, ImageTinySerializer
 from djangoplicity.metadata.api.v2.serializers import ProgramSerializer
 from djangoplicity.archives.api.v2.serializers import ArchiveSerializerMixin
 
@@ -44,30 +44,25 @@ class ReleaseMiniSerializer(ReleaseSerializerMixin, serializers.ModelSerializer)
             'main_image',
         ]
 
-    @extend_schema_field(ImageMiniSerializer)
+    @extend_schema_field(ImageMiniSerializer())
     def get_main_image(self, obj):
         request = self.context.get('request')
         has_gemini_program_flag = has_gemini_program_request(request)
+        has_tiny_param = request and request.query_params.get('tiny') == 'true'
 
-        suffix = 'gemini' if has_gemini_program_flag else 'default'
-        cache_key = f"release_main_image_{obj.id}_{suffix}"
-        cache_timeout = getattr(settings, 'RELEASES_CACHE_TIMEOUT', 60 * 60 * 2) # 2 hours
+        context = {**self.context, 'has_gemini_program': has_gemini_program_flag}
+        serializer_class = ImageTinySerializer if has_tiny_param else ImageMiniSerializer
 
-        cached = cache.get(cache_key)
-        if cached is not None:
-            return cached
-
-        images = related_archive_items(Release.related_images, obj)
-        if not images:
-            cache.set(cache_key, None, timeout=cache_timeout) 
+        if hasattr(obj, '_main_image_cache'):
+            main_image = obj._main_image_cache
+        else:
+            images = related_archive_items(Release.related_images, obj)
+            main_image = images[0] if images else None
+        
+        if not main_image:
             return None
         
-        # By default, related_archive_items put 'main visual' images first, then we can simply return the first one
-        context = {**self.context, 'has_gemini_program': has_gemini_program_flag}
-        data = ImageMiniSerializer(images[0], context=context).data
-        
-        cache.set(cache_key, data, timeout=cache_timeout)
-        return data
+        return serializer_class(main_image, context=context).data
 
 
 class ReleaseSerializer(ReleaseSerializerMixin, serializers.ModelSerializer):

--- a/djangoplicity/releases/api/v2/views.py
+++ b/djangoplicity/releases/api/v2/views.py
@@ -120,6 +120,11 @@ class ReleaseViewMixin:
             enum=[t[0] for t in RELEASE_TYPE_CHOICES],
             description=f"Default: {RELEASE_TYPE_PUBLIC}"
         ),
+        OpenApiParameter(
+            "tiny",
+            OpenApiTypes.BOOL,
+            description="If true returns a simplified response for the main image with minimal fields and few formats. Default: false"
+        )
     ],
 )
 class ReleaseListView(mixins.ListModelMixin, ReleaseViewMixin, TranslationAPIViewMixin, GenericViewSet):
@@ -128,6 +133,18 @@ class ReleaseListView(mixins.ListModelMixin, ReleaseViewMixin, TranslationAPIVie
     pagination_class = ReleasesPagination
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = ReleaseFilter
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        # Pre-fetch main visuals for better performance
+        Release.store_main_visuals(queryset)
+        print("Precargado todo")
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
 
 
 @extend_schema(

--- a/djangoplicity/releases/api/v2/views.py
+++ b/djangoplicity/releases/api/v2/views.py
@@ -138,7 +138,6 @@ class ReleaseListView(mixins.ListModelMixin, ReleaseViewMixin, TranslationAPIVie
         queryset = self.filter_queryset(self.get_queryset())
         # Pre-fetch main visuals for better performance
         Release.store_main_visuals(queryset)
-        print("Precargado todo")
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)


### PR DESCRIPTION
## Description
1. The Announcement and Releases views were updated to override the list method, incorporating the use of `store_main_visuals`. This method, used in NOIRLab for rendering HTML (Options.py & Browser), optimizes SQL queries by retrieving the main image for all objects in a single query, instead of one for each announcement or release.

2. This optimization significantly improves API performance, as the serializer is no longer overloaded with image retrieval logic.

3. In addition, the respective serializers were updated to simplify the main image formats based on the tiny parameter. Since `store_main_visuals` acts as a cache at the queryset level, the additional caching previously implemented in the serializers was removed.

## Results Before Optimization
- Parameters `tiny=true` and `page_size=30`, response `time 2.08s`
<img width="1078" height="715" alt="no_op_tiny_30items" src="https://github.com/user-attachments/assets/ea792122-c669-475c-928d-e7897e7b362e" />

- Without the tiny parameter, only the `page_size=30`, response `time 2.44s`
<img width="1078" height="715" alt="no_op_30items" src="https://github.com/user-attachments/assets/cd7aad54-da58-4137-b2a0-f106f22be772" />

## Results After Optimization
- Parameters `tiny=true` and `page_size=30`, response `time 477ms`
<img width="1078" height="715" alt="op_tiny_30items" src="https://github.com/user-attachments/assets/afd62eb8-3582-468c-932c-80b540ae4a11" />

- Without the `tiny=true` and `page_size=30`, response `time between 500-600ms`
<img width="2032" height="976" alt="op_30items" src="https://github.com/user-attachments/assets/98c6f7b2-0fc7-4c66-ae52-dad3459c3c75" />
