### PR TITLE
Fix/Allow main image to use multiple serializers via PolymorphicProxySerializer in Announcements & Press Releases endpoints

### DIFF
--- a/djangoplicity/announcements/api/v2/serializers.py
+++ b/djangoplicity/announcements/api/v2/serializers.py
@@ -1,5 +1,5 @@
 from djangoplicity.announcements.models import Announcement
-from drf_spectacular.utils import extend_schema_field
+from drf_spectacular.utils import extend_schema_field, PolymorphicProxySerializer
 from rest_framework import serializers
 from djangoplicity.archives.utils import related_archive_items
 
@@ -29,7 +29,13 @@ class AnnouncementMiniSerializer(ArchiveSerializerMixin, serializers.ModelSerial
             'main_image',
         ]
 
-    @extend_schema_field(ImageMiniSerializer())
+    @extend_schema_field(
+        PolymorphicProxySerializer(
+            component_name='MainImage',
+            serializers=[ImageTinySerializer, ImageMiniSerializer],
+            resource_type_field_name=None
+        )
+    )
     def get_main_image(self, obj):
         request = self.context.get('request')
         has_gemini_program_flag = has_gemini_program_request(request)

--- a/djangoplicity/releases/api/v2/serializers.py
+++ b/djangoplicity/releases/api/v2/serializers.py
@@ -1,5 +1,5 @@
 from djangoplicity.releases.models import Release, ReleaseContact
-from drf_spectacular.utils import extend_schema_field
+from drf_spectacular.utils import extend_schema_field, PolymorphicProxySerializer
 from rest_framework import serializers
 from djangoplicity.archives.utils import related_archive_items, get_all_instance_archives_urls
 
@@ -44,7 +44,13 @@ class ReleaseMiniSerializer(ReleaseSerializerMixin, serializers.ModelSerializer)
             'main_image',
         ]
 
-    @extend_schema_field(ImageMiniSerializer())
+    @extend_schema_field(
+        PolymorphicProxySerializer(
+            component_name='MainImage',
+            serializers=[ImageTinySerializer, ImageMiniSerializer],
+            resource_type_field_name=None
+        )
+    )
     def get_main_image(self, obj):
         request = self.context.get('request')
         has_gemini_program_flag = has_gemini_program_request(request)


### PR DESCRIPTION
## Screenshots

### Tiny: False

<img width="1363" height="1016" alt="image" src="https://github.com/user-attachments/assets/b9c3002e-cf98-4837-899c-ace8d5cd66d0" />

### Tiny: True

<img width="1363" height="1016" alt="image" src="https://github.com/user-attachments/assets/add3f097-10a7-4623-8209-9ef13f5c0594" />

### Schema definition in API Documentation:

<img width="953" height="499" alt="image" src="https://github.com/user-attachments/assets/e825cf79-923f-4ded-955b-533e004b9b2f" />
