### PR TITLE
Fix/Use serializer context for tiny images and gemini flags 

### DIFF
--- a/djangoplicity/announcements/api/v2/serializers.py
+++ b/djangoplicity/announcements/api/v2/serializers.py
@@ -9,7 +9,6 @@ from djangoplicity.archives.api.v2.serializers import ArchiveSerializerMixin
 
 from django.core.cache import cache
 from django.conf import settings
-from djangoplicity.utils.domain_rewrite import has_gemini_program_request
 
 
 class AnnouncementMiniSerializer(ArchiveSerializerMixin, serializers.ModelSerializer):
@@ -37,11 +36,7 @@ class AnnouncementMiniSerializer(ArchiveSerializerMixin, serializers.ModelSerial
         )
     )
     def get_main_image(self, obj):
-        request = self.context.get('request')
-        has_gemini_program_flag = has_gemini_program_request(request)
-        has_tiny_param = request and request.query_params.get('tiny') == 'true'
-
-        context = {**self.context, 'has_gemini_program': has_gemini_program_flag}
+        has_tiny_param = self.context.get('tiny', False)
         serializer_class = ImageTinySerializer if has_tiny_param else ImageMiniSerializer
 
         if hasattr(obj, '_main_image_cache'):
@@ -53,7 +48,7 @@ class AnnouncementMiniSerializer(ArchiveSerializerMixin, serializers.ModelSerial
         if not main_image:
             return None
         
-        return serializer_class(main_image, context=context).data
+        return serializer_class(main_image, context=self.context).data
 
 
 class AnnouncementSerializer(ArchiveSerializerMixin, serializers.ModelSerializer):

--- a/djangoplicity/announcements/api/v2/views.py
+++ b/djangoplicity/announcements/api/v2/views.py
@@ -10,6 +10,8 @@ from .serializers import AnnouncementMiniSerializer, AnnouncementSerializer
 from rest_framework import permissions, mixins
 from rest_framework.viewsets import GenericViewSet
 from django_filters import rest_framework as filters
+from djangoplicity.utils.domain_rewrite import has_gemini_program_request
+
 
 
 class AnnouncementPagination(PageNumberPagination):
@@ -112,6 +114,14 @@ class AnnouncementListView(mixins.ListModelMixin, AnnouncementViewMixin, Transla
 
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
+    
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+
+        context['tiny'] = self.request.query_params.get('tiny', 'false').lower() == 'true'
+        context['has_gemini_program'] = has_gemini_program_request(self.request)
+
+        return context
 
 
 class AnnouncementDetailView(mixins.RetrieveModelMixin, AnnouncementViewMixin, TranslationAPIViewMixin, GenericViewSet):

--- a/djangoplicity/media/api/v2/serializers.py
+++ b/djangoplicity/media/api/v2/serializers.py
@@ -45,10 +45,7 @@ class ImageMiniSerializer(ImageSerializerMixin, serializers.ModelSerializer):
     def to_representation(self, instance):
         data = super().to_representation(instance)
         
-        context = self.context or {}
-        request = context.get('request')
-        
-        if context.get('has_gemini_program') or has_gemini_category_request(request):
+        if self.context.get('has_gemini_program') or self.context.get('has_gemini_category'):
             data = replace_gemini_domains(data)
         
         return data
@@ -66,12 +63,9 @@ class ImageTinySerializer(ArchiveSerializerMixin, serializers.ModelSerializer):
     def to_representation(self, instance):
         data = super().to_representation(instance)
 
-        context = self.context or {}
-        request = context.get('request')
-
-        if has_gemini_category_request(request):
+        if self.context.get('has_gemini_program') or self.context.get('has_gemini_category'):
             data = replace_gemini_domains(data)
-
+        
         return data
 
 
@@ -102,13 +96,11 @@ class VideoMiniSerializer(VideoSerializerMixin, serializers.ModelSerializer):
     def to_representation(self, instance):
         data = super().to_representation(instance)
 
-        context = self.context or {}
-        request = context.get('request')
-
-        if has_gemini_category_request(request):
+        if self.context.get('has_gemini_program') or self.context.get('has_gemini_category'):
             data = replace_gemini_domains(data)
-
+        
         return data
+
 
 class VideoSerializer(VideoSerializerMixin, serializers.ModelSerializer):
     class Meta:

--- a/djangoplicity/media/api/v2/views.py
+++ b/djangoplicity/media/api/v2/views.py
@@ -12,6 +12,7 @@ from .serializers import ImageSerializer, ImageMiniSerializer, ImageTinySerializ
 from rest_framework import permissions, mixins
 from rest_framework.viewsets import GenericViewSet
 from django_filters import rest_framework as filters
+from djangoplicity.utils.domain_rewrite import has_gemini_category_request
 
 
 class MediaPagination(PageNumberPagination):
@@ -109,6 +110,12 @@ class ImageListView(mixins.ListModelMixin, ImageViewMixin, TranslationAPIViewMix
         if self.request.GET.get('tiny', 'false') == 'true':
             return ImageTinySerializer
         return ImageMiniSerializer
+    
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context['has_gemini_category'] = has_gemini_category_request(self.request)
+
+        return context
 
 
 class ImageDetailView(mixins.RetrieveModelMixin, ImageViewMixin, TranslationAPIViewMixin, GenericViewSet):
@@ -140,6 +147,12 @@ class VideoListView(mixins.ListModelMixin, VideoViewMixin, TranslationAPIViewMix
     pagination_class = MediaPagination
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = VideoFilter
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context['has_gemini_category'] = has_gemini_category_request(self.request)
+
+        return context
 
 
 class VideoDetailView(mixins.RetrieveModelMixin, VideoViewMixin, TranslationAPIViewMixin, GenericViewSet):

--- a/djangoplicity/releases/api/v2/serializers.py
+++ b/djangoplicity/releases/api/v2/serializers.py
@@ -52,12 +52,8 @@ class ReleaseMiniSerializer(ReleaseSerializerMixin, serializers.ModelSerializer)
         )
     )
     def get_main_image(self, obj):
-        request = self.context.get('request')
-        has_gemini_program_flag = has_gemini_program_request(request)
-        has_tiny_param = request and request.query_params.get('tiny') == 'true'
-
-        context = {**self.context, 'has_gemini_program': has_gemini_program_flag}
-        serializer_class = ImageTinySerializer if has_tiny_param else ImageMiniSerializer
+        is_tiny = self.context.get('tiny', False)
+        serializer_class = ImageTinySerializer if is_tiny else ImageMiniSerializer
 
         if hasattr(obj, '_main_image_cache'):
             main_image = obj._main_image_cache
@@ -68,7 +64,7 @@ class ReleaseMiniSerializer(ReleaseSerializerMixin, serializers.ModelSerializer)
         if not main_image:
             return None
         
-        return serializer_class(main_image, context=context).data
+        return serializer_class(main_image, context=self.context).data
 
 
 class ReleaseSerializer(ReleaseSerializerMixin, serializers.ModelSerializer):

--- a/djangoplicity/releases/api/v2/views.py
+++ b/djangoplicity/releases/api/v2/views.py
@@ -17,6 +17,7 @@ from .serializers import ReleaseMiniSerializer, ReleaseSerializer
 from rest_framework import permissions, mixins
 from rest_framework.viewsets import GenericViewSet
 from django_filters import rest_framework as filters
+from djangoplicity.utils.domain_rewrite import has_gemini_program_request
 
 
 class StagingPermission(permissions.BasePermission):
@@ -144,6 +145,14 @@ class ReleaseListView(mixins.ListModelMixin, ReleaseViewMixin, TranslationAPIVie
             return self.get_paginated_response(serializer.data)
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
+    
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+
+        context['tiny'] = self.request.query_params.get('tiny', 'false').lower() == 'true'
+        context['has_gemini_program'] = has_gemini_program_request(self.request)
+
+        return context
 
 
 @extend_schema(


### PR DESCRIPTION
## Description
This change passes the tiny and gemini flags from the views to the serializers using `get_serializer_context`.

It lets nested image serializers choose the correct format (tiny or mini for announcements and press releases) and replace domains in a safe and consistent way for gemini images.

In development this worked most of the time, but in production it was not reliable because the serializer context could be lost. This change makes sure the correct context is always set in the view and used by the serializers.

It also avoids reading query parameters inside serializers and fixes different behavior between development and production.
