### PR TITLE
Fix/40ktiff

### DIFF
--- a/djangoplicity/archives/contrib/types/images.py
+++ b/djangoplicity/archives/contrib/types/images.py
@@ -32,6 +32,7 @@ class PublicationTiff40KType(TiffType):
     verbose_name = _(u'Publication TIFF 40K')
     size = 40000
     required = False
+    needs_bigtiff = True
 
 
 class PublicationTiff25KType(TiffType):

--- a/djangoplicity/cutter/imagemagick.py
+++ b/djangoplicity/cutter/imagemagick.py
@@ -65,7 +65,7 @@ IM_LIMITS = '-limit memory 6GiB -limit map 6GiB -limit thread 8'
 IM_TMP_DIR = os.path.join(settings.TMP_DIR, 'imagemagick')
 os.makedirs(IM_TMP_DIR, exist_ok=True)
 
-CONVERT_DEFAULTS = '-quiet -depth 8 -colorspace sRGB +antialias'
+CONVERT_DEFAULTS = '-quiet -colorspace sRGB +antialias'
 if os.path.isdir(IM_TMP_DIR):
     CONVERT_DEFAULTS += ' -define registry:temporary-path={}'.format(IM_TMP_DIR)
 
@@ -203,10 +203,21 @@ def _get_convert_args(archive, width, height, fmt, tmp_path, output_dir):
     args += ['-profile', SRGB_PROFILE]
 
     # Input file
+    depth = getattr(archive, '_bit_depth', 8) # Fallback to 8 bits if not set
+
     args += [tmp_path]
+    args += ['-depth', str(depth)]
+
 
     # Output path
-    output_path = os.path.join(output_dir, '%s.%s' % (archive.pk, fmt.type.exts[0]))
+    output_path = os.path.join(
+        output_dir,
+        '%s.%s' % (archive.pk, fmt.type.exts[0])
+    )
+
+    # Force BigTIFF when needed
+    if fmt.type.exts[0] in ('tif', 'tiff') and _must_use_bigtiff(fmt, width, height):
+        output_path = 'tiff64:%s' % output_path
 
     if hasattr(fmt.type, 'force_format'):
         # In some cases we force a different format than the extension's default
@@ -415,6 +426,19 @@ def _generate_zoomify(archive, width, height, tmp_dir, dest_dir):
     shutil.move(zoomable_dir, target)
 
 
+def _must_use_bigtiff(fmt, width, height):
+    '''
+    Returns True if the format requires BigTIFF
+    '''
+    # If the format has needs_bigtiff flag set, always use BigTIFF
+    if getattr(fmt.type, 'needs_bigtiff', False):
+        logger.info('Format %s requires BigTIFF', fmt.type.verbose_name)
+        return True
+
+    # General rule: use BigTIFF if width or height exceeds 30000 pixels
+    return max(width, height) > 30000
+
+
 def identify_image(path):
     '''
     Returns the image resolution
@@ -433,6 +457,22 @@ def identify_image(path):
     width, height = output.split(';')[0].split()
 
     return int(width), int(height)
+
+def identify_image_with_depth(path):
+    '''
+    Returns the image resolution (width, height) and depth
+    '''
+    identify_args = IDENTIFY.split()
+    identify_args += ['-quiet', '-format', '%w %h %z;', path]
+
+    identify = Popen(identify_args, stdout=PIPE, encoding='utf8')
+    output = identify.communicate()[0]
+
+    try:
+        width, height, depth = output.split(';')[0].split()
+        return int(width), int(height), int(depth)
+    except (ValueError, IndexError) as e:
+        raise Exception(f'Failed to parse image dimensions from identify output for {path}: {output.strip()}. Error: {str(e)}')
 
 
 def process_image_derivatives(app_label, module_name, pk, formats,
@@ -488,7 +528,8 @@ def process_image_derivatives(app_label, module_name, pk, formats,
         raise Exception(error)
 
     # Get the original file resolution:
-    width, height = identify_image(original.path)
+    width, height, depth = identify_image_with_depth(original.path)
+    archive._bit_depth = depth
 
     # We keep track of the required formats which can't be generated, and
     # formats which we have to upscale:


### PR DESCRIPTION
### Work in Progress. Keep testing with another images.

This PR updates the image derivative generation to better preserve image fidelity and correctly handle large TIFF outputs.

### Bit depth preservation

The bit depth of the original image is now explicitly detected using ImageMagick (identify, %z) and stored on the archive instance.
When generating derived images, this value is passed to convert via -depth, ensuring that 16-bit originals remain 16-bit and are no longer implicitly downgraded to 8-bit.

### Publication TIFF 40K as BigTIFF

Based on the discussion with Madhi and Lars, Publication TIFF 40K is now generated as BigTIFF.
This avoids the size and dimension limits of classic TIFF files for very large images.

BigTIFF output is enforced by using the tiff64: prefix in the ImageMagick output path, which is the supported mechanism according to convert -list format.

### Current scope

The change currently applies only to Publication TIFF 40K.
it still needs to be validated with real 40K images to fully confirm correctness and performance.

> Note: While the implementation is complete, it has not yet been tested with real 40K images and will need validation in a production-like environment.


### Results with image noirlab2027a
The original image contains the following metadata. The relevant fields show that the file type is TIFF and the MIME type is image/tiff, which confirms that the image is stored as a classic TIFF file.

<img width="1442" height="602" alt="image" src="https://github.com/user-attachments/assets/5d080349-c128-40ce-b59a-7897cacdc451" />

After applying the changes and generating the 40k publication TIFF, the resulting image shows different metadata. The MIME type is now image/x-tiff-big, and ExifTool reports the file type as BTF (BigTIFF), confirming that the output was generated using the BigTIFF format.

<img width="1448" height="540" alt="image" src="https://github.com/user-attachments/assets/878605de-0e4b-4a64-9e1d-3add5a862f30" />

Additionally, based on the findings discussed with Mahdi, a BigTIFF file can be identified by inspecting the TIFF header. In a BigTIFF file, the TIFF version field contains the hexadecimal value 2B (decimal 43), whereas a classic TIFF contains 2A (decimal 42).
The hexadecimal inspection shown below confirms that the generated 40k image contains 2B, verifying that the conversion to BigTIFF was successful.

<img width="1270" height="232" alt="image" src="https://github.com/user-attachments/assets/04d149d4-b9bd-47cc-bae4-cfeb77811205" />


