### PR TITLE
feature/Add WebP derivative format for archive images to improve performance

### DIFF
--- a/djangoplicity/archives/contrib/types/images.py
+++ b/djangoplicity/archives/contrib/types/images.py
@@ -83,6 +83,11 @@ class LargeJpegType(ImageFileType):
     compression_quality = 90
     content_type = 'image/jpeg'
 
+class WebPType(ImageFileType):
+    verbose_name = _('WebP')
+    exts = ['webp']
+    compression_quality = 80
+    content_type = 'image/webp'
 
 class PublicationJpegType(JpegType):
     verbose_name = _(u'Publication JPEG')
@@ -300,5 +305,12 @@ class Poster400yType(JpegType):
     compression_quality = 85
     width = 282
     height = 400
+    unsharp = 25
+    upscale = True
+
+class ScreensizeWebPType(WebPType):
+    verbose_name = _(u'Screensize WebP')
+    compression_quality = 80 
+    width = 1280
     unsharp = 25
     upscale = True

--- a/djangoplicity/media/models/images.py
+++ b/djangoplicity/media/models/images.py
@@ -914,6 +914,7 @@ class Image( ArchiveModel, TranslationModel, ContentDeliveryModel, CropModel ):
         screen640 = ImageResourceManager(derived='publicationtiff', type=types.Screen640Type)
         portrait1080 = ImageResourceManager(derived='publicationtiff', type=types.Portrait1080Type)
         poster400y = ImageResourceManager(derived='publicationtiff', type=types.Poster400yType)
+        webp = ImageResourceManager(derived='publicationtiff', type=types.ScreensizeWebPType)
 
         pl_original = ImageResourceManager(type=types.OriginalImageType)
         pl_screen = ImageResourceManager(derived='pl_original', type=types.ScreensizeJpegType)


### PR DESCRIPTION
I have added a new WebP image derivative to the archive model by introducing WebPType and registering it via ImageResourceManager, enabling more efficient image delivery on the KPNO site through better compression and improved performance, especially on mobile devices.