### PR TITLE
Fix/logic error in get_access_tag_for_format method

### DIFF
--- a/djangoplicity/archives/base.py
+++ b/djangoplicity/archives/base.py
@@ -821,7 +821,7 @@ class ArchiveModel( with_metaclass(ArchiveBase, object) ):
         is_embargoed = self.is_embargoed()
         
         content_server = MEDIA_CONTENT_SERVERS[self.content_server]
-        if not content_server and not content_server.always_public_formats:
+        if not content_server:
             return AccessTagControl.PUBLIC
 
         if is_embargoed and fmt in content_server.always_public_formats:

--- a/djangoplicity/archives/base.py
+++ b/djangoplicity/archives/base.py
@@ -824,8 +824,9 @@ class ArchiveModel( with_metaclass(ArchiveBase, object) ):
         if not content_server:
             return AccessTagControl.PUBLIC
 
-        if is_embargoed and fmt in content_server.always_public_formats:
-            return AccessTagControl.PUBLIC
+        if is_embargoed and hasattr(content_server, 'always_public_formats'):
+            if fmt in content_server.always_public_formats:
+                return AccessTagControl.PUBLIC
 
         return base_access_tag
 


### PR DESCRIPTION
Fixed AttributeError in` get_access_tag_for_format` by adding proper `hasattr `check for `always_public_formats attribute`. Also corrected logic condition that was causing issues when `content_server was None`. This ensures consistent access tag behavior across different content server configurations.