### PR TITLE
Fix/remove constellation URL generation in calculate_constellation function

### DIFF
--- a/djangoplicity/media/info.py
+++ b/djangoplicity/media/info.py
@@ -280,10 +280,6 @@ def calculate_constellation(obj):
         return ''
     try:
         _abbr, const = ephem.constellation([ephem.hours(a), ephem.degrees(b)])
-        if const:
-            clean_const = const.replace(" ", "").lower()
-            constellation_url = ('<a href=\"https://noirlab.edu/public/education/constellations/%s\">%s</a>' % (clean_const,ugettext(const)))
-            return mark_safe( constellation_url )
     except SystemError:
         return ''
     return const


### PR DESCRIPTION
## Fix bug CEE-6788

- Update calculate_constellation to return the constellation name instead of an HTML anchor tag.
- Before deploying, run the migration script to strip <a> tags from existing constellation values, leaving only the plain text (e.g. Taurus).

## Code

```python
import re
from django.db import transaction
from djangoplicity.media.models import Image

anchor_pattern = re.compile(r'<a\s[^>]*>(.*?)</a>', re.IGNORECASE)

qs = Image.objects.filter(constellation__isnull=False).filter(constellation__contains='<a')
images_to_update = []

for im in qs.iterator():
    cleaned = anchor_pattern.sub(r'\1', im.constellation).strip()
    print(f"[{im.id}] '{im.constellation}' → '{cleaned}'")
    im.constellation = cleaned
    images_to_update.append(im)

print(f"\n{len(images_to_update)} imágenes a actualizar.")

with transaction.atomic():
    Image.objects.bulk_update(images_to_update, ['constellation'])

print("Todo actualizado!!")
```