### PR TITLE
Refactor/Async task to clean up resources to improve performance

### DIFF
--- a/djangoplicity/contentserver/tasks.py
+++ b/djangoplicity/contentserver/tasks.py
@@ -454,7 +454,7 @@ def _is_within_allowed_subdir(resource_path, allowed_subdirs):
     return False
 
 
-def _is_ready_for_deletion(resource, content_server):
+def _is_ready_for_deletion(resource, content_server, is_dir=False):
     related_object = resource.content_object
 
     if not related_object:
@@ -468,9 +468,14 @@ def _is_ready_for_deletion(resource, content_server):
 
     # 2. Check file exists in S3
     s3_path = content_server.to_s3_path(resource.content_server_path)
-    if not content_server.file_exists(s3_path):
-        logger.warning(f"Resource {resource.id} does not exist in S3 at '{s3_path}', skipping")
-        return False
+    if is_dir:
+        if not content_server.directory_exists(s3_path):
+            logger.warning(f"Directory resource {resource.id} does not exist in S3 at '{s3_path}', skipping")
+            return False
+    else:   
+        if not content_server.file_exists(s3_path):
+            logger.warning(f"Resource {resource.id} does not exist in S3 at '{s3_path}', skipping")
+            return False
 
     return True
 

--- a/djangoplicity/contentserver/tasks.py
+++ b/djangoplicity/contentserver/tasks.py
@@ -388,7 +388,7 @@ def cleanup_old_local_resources(weeks=4):
 
     deleted_count = 0
     
-    for resource in resources:
+    for resource in resources.iterator(chunk_size=1000):
         resource_path = os.path.normpath(
             os.path.join(settings.BASE_DIR, resource.content_server_path)
         )

--- a/djangoplicity/contentserver/tasks.py
+++ b/djangoplicity/contentserver/tasks.py
@@ -406,15 +406,16 @@ def cleanup_old_local_resources(weeks=4):
             continue
 
         try:
+            if not os.path.exists(resource_path):
+                logger.info(f"Resource {resource.id} file not found on disk at {resource_path}")
+                continue
+
             if not _is_ready_for_deletion(resource, content_server):
                 continue
 
-            if os.path.exists(resource_path):
-                os.remove(resource_path)
-                deleted_count += 1
-                logger.info(f"Deleted resource {resource.id} from disk: {resource_path}")
-            else:
-                logger.info(f"Resource {resource.id} file not found on disk at {resource_path}")
+            os.remove(resource_path)
+            deleted_count += 1
+            logger.info(f"Deleted resource {resource.id} from disk: {resource_path}")  
                 
         except Exception as e:
             logger.error(f"Error processing resource {resource.id}: {e}")

--- a/djangoplicity/contentserver/tasks.py
+++ b/djangoplicity/contentserver/tasks.py
@@ -45,6 +45,7 @@ from django.contrib.contenttypes.models import ContentType
 from djangoplicity.archives.utils import get_all_possible_instance_formats, get_instance_checksum, initialize_resource
 import time
 import os
+import shutil
 
 logger = get_task_logger(__name__)
 
@@ -360,21 +361,9 @@ def cleanup_old_local_resources_task():
 
 
 def cleanup_old_local_resources(weeks=4):
-    from djangoplicity.contentserver.models import ContentServerResource
     from djangoplicity.media.models import Image, Video
     
     cutoff_date = timezone.now() - timedelta(weeks=weeks)
-
-    resources = ContentServerResource.objects.filter(
-        created_at__lt=cutoff_date,
-        updated_at__lt=cutoff_date,
-        is_active=True
-    )
-
-    if not resources.exists():
-        logger.info("No local resources found for cleanup older than %s weeks", weeks)
-        return 0
-    
     media_root = os.path.normpath(settings.MEDIA_ROOT)
     
     allowed_content_types = {
@@ -382,44 +371,51 @@ def cleanup_old_local_resources(weeks=4):
         ContentType.objects.get_for_model(Video),
     }
     
-    allowed_subdirs = [
+    allowed_dirs = [
         os.path.join(media_root, "archives", "videos"),
         os.path.join(media_root, "archives", "images"),
     ]
 
     deleted_count = 0
     
-    for resource in resources.iterator(chunk_size=1000):
-        resource_path = os.path.normpath(
-            os.path.join(settings.BASE_DIR, resource.content_server_path)
-        )
-
-        if not _is_valid_resource(resource, resource_path, media_root, allowed_content_types, allowed_subdirs):
-            continue
-
-        try:
-            content_server = MEDIA_CONTENT_SERVERS[resource.content_server]
-            if not content_server:
-                logger.warning(f"Content server {resource.content_server} not found")
+    for allowed_dir in allowed_dirs:
+        for dirpath, dirnames, filenames in os.walk(allowed_dir):
+            
+            if dirpath == allowed_dir:
                 continue
-        except KeyError:
-            logger.warning(f"Unknown content server: {resource.content_server}")
-            continue
+            
+            format = os.path.basename(dirpath)
+            logger.info(f"Processing directory: {dirpath}, format: {format}")
 
-        try:
-            if not os.path.exists(resource_path):
-                logger.info(f"Resource {resource.id} file not found on disk at {resource_path}")
-                continue
+            if format == "zoomable":
+                ids = list(dirnames)
+                resources_map = _get_resources_map(cutoff_date, allowed_content_types, ids, format)
+                deleted_count += _process_entries(dirpath, dirnames, resources_map, is_dir=True)
 
-            if not _is_ready_for_deletion(resource, content_server):
-                continue
-
-            os.remove(resource_path)
-            deleted_count += 1
-            logger.info(f"Deleted resource {resource.id} from disk: {resource_path}")  
+                dirnames.clear()  # Don't traverse into zoomable directories
+            else:
+                ids = [os.path.splitext(f)[0] for f in filenames]
+                resources_map = _get_resources_map(cutoff_date, allowed_content_types, ids, format)
                 
-        except Exception as e:
-            logger.error(f"Error processing resource {resource.id}: {e}")
+                deleted_count += _process_entries(dirpath, filenames, resources_map)                   
+
+    return deleted_count
+
+
+def _process_entries(dirpath, entries, resources_map, is_dir=False):
+    """Iterate entries, delete those with a valid resource. Returns deleted count."""
+    deleted_count = 0
+
+    for entry in entries:
+        entry_id = entry if is_dir else os.path.splitext(entry)[0]
+
+        resource = resources_map.get(entry_id)
+        logger.info(f"Checking entry: {entry}, resource found: {bool(resource)}")
+        if not resource:
+            continue
+
+        if _try_delete_path(resource, os.path.join(dirpath, entry), is_dir=is_dir):
+            deleted_count += 1
 
     return deleted_count
 

--- a/djangoplicity/contentserver/tasks.py
+++ b/djangoplicity/contentserver/tasks.py
@@ -372,6 +372,7 @@ def cleanup_old_local_resources(weeks=4):
     )
 
     if not resources.exists():
+        logger.info("No local resources found for cleanup older than %s weeks", weeks)
         return 0
     
     media_root = os.path.normpath(settings.MEDIA_ROOT)

--- a/djangoplicity/contentserver/tasks.py
+++ b/djangoplicity/contentserver/tasks.py
@@ -424,34 +424,46 @@ def cleanup_old_local_resources(weeks=4):
     return deleted_count
 
 
-def _is_valid_resource(resource, resource_path, media_root, allowed_content_types, allowed_subdirs):
-
-    # 1. Check content type
-    if resource.content_type not in allowed_content_types:
-        logger.warning(f"Resource {resource.id} content type '{resource.content_type}' is not Image or Video, skipping")
+def _try_delete_path(resource, path, is_dir=False):
+    """Attempt to delete a file from disk. Returns True if deleted."""
+    try:
+        content_server = MEDIA_CONTENT_SERVERS[resource.content_server]
+    except KeyError:
+        logger.warning(f"Unknown content server '{resource.content_server}' for resource {resource.object_id}, skipping")
         return False
 
-    # 2. Check media root
-    if not resource_path.startswith(media_root + os.sep):
-        logger.warning(f"Resource {resource.id} path '{resource.content_server_path}' is not within MEDIA_ROOT, skipping")
+    if not _is_ready_for_deletion(resource, content_server, is_dir=is_dir):
         return False
 
-    # 3. Check allowed subdirectories
-    if not _is_within_allowed_subdir(resource_path, allowed_subdirs):
-        logger.warning(f"Resource {resource.id} path '{resource.content_server_path}' is not within allowed subdirectories (archives/videos, archives/imagenes), skipping")
+    try:
+        if is_dir:
+            shutil.rmtree(path)
+        else:
+            os.remove(path)
+        logger.info(f"Deleted local resource {resource.object_id}: {path}")
+        return True
+    except Exception as e:
+        logger.warning(f"Failed to delete {path} for resource {resource.object_id}: {e}")
         return False
 
-    return True
 
+def _get_resources_map(cutoff_date, allowed_content_types, ids, format):
+    """Fetch matching resources for a format."""
+    from djangoplicity.contentserver.models import ContentServerResource
 
-def _is_within_allowed_subdir(resource_path, allowed_subdirs):
-    for allowed_dir in allowed_subdirs:
-        try:
-            if os.path.commonpath([resource_path, allowed_dir]) == allowed_dir:
-                return True
-        except ValueError:
-            continue
-    return False
+    qs = ContentServerResource.objects.filter(
+        object_id__in=ids,
+        format=format,
+        content_type__in=allowed_content_types,
+        created_at__lt=cutoff_date,
+        updated_at__lt=cutoff_date,
+    ).select_related('content_type').iterator(chunk_size=1000)
+
+    resources_map = {}
+    for r in qs:
+        resources_map[r.object_id] = r
+    
+    return resources_map
 
 
 def _is_ready_for_deletion(resource, content_server, is_dir=False):


### PR DESCRIPTION
## Description

Refactor `cleanup_old_local_resources` to improve performance and memory usage during local resource cleanup.

Previously, the cleanup process started by querying all matching `ContentServerResource objects from the database`. In large environments this could mean iterating over 300k–400k records, causing unnecessary database load, increased memory consumption, and slow execution times.

### The new approach reverses the workflow:

- Instead of starting from the database, it now scans the local filesystem using `os.walk.`
- Only resources that actually exist on disk are queried from the database.
- Database queries are now limited to small batches of resource IDs extracted from local files/directories.
- Query iteration now uses iterator(chunk_size=1000) to avoid loading large querysets into memory at once.

### Main Changes

- Refactor cleanup flow to iterate local filesystem entries first instead of querying all ContentServerResource objects.
- Add support for zoomable resources stored as directories.
- Reduce memory usage by using queryset iteration with chunk_size=1000.
- Improve deletion flow separation by splitting responsibilities into smaller helper functions.
- Remove path validation logic that is no longer necessary with the filesystem-first approach.
**** 
### New Functions
#### _process_entries
- Iterates local filesystem entries and processes matching resources.
#### _try_delete_path
- Centralizes deletion logic for both files and directories.
#### _get_resources_map
- Fetches only matching resources for discovered local entries.
- Uses .iterator(chunk_size=1000) to avoid loading large querysets into RAM.
****
### Updated Functions
#### cleanup_old_local_resources
Completely refactored to:

- Traverse local directories using os.walk
- Extract resource IDs from filenames/directories
- Query only required resources
- Handle both files and directory-based resources

#### _is_ready_for_deletion
- Extended to support directory validation for zoomable resources using directory_exists.
****
### Removed Functions
#### _is_valid_resource
- Removed because validation based on path safety and allowed subdirectories is no longer needed after switching to filesystem-driven traversal.
#### _is_within_allowed_subdir
- Removed together with _is_valid_resource since directory traversal is now explicitly limited to allowed directories.
