### PR TITLE
Fix/Return public access tag for resources without an access tag

### DIFF
--- a/djangoplicity/contentserver/base.py
+++ b/djangoplicity/contentserver/base.py
@@ -291,7 +291,8 @@ class S3ContentServer(ContentServer):
             logger.warning('S3ContentServer: Could not read privacy tag for %s: %s', remote_path, e)
             return None
 
-        return None
+        # If no access tag is found, assume it's public
+        return AccessTagControl.PUBLIC.value
     
     def is_publicly_accessible(self, resource):
         """Return True if the resource is public, False otherwise."""


### PR DESCRIPTION
Changed `get_resource_privacy` to return "public" instead of None when an S3 resource doesn't have an Access tag. Previously, resources without privacy tags were incorrectly marked as non-public (false positives). Now they default to public, matching the expected behavior where untagged resources are publicly accessible.