### PR TITLE
Fix/Add correct access tag for zoomable format based on directories, option to change privacy from admin site, and filter for ContentServerResources for elements that doesn't have a linked object

### DIFF
--- a/djangoplicity/archives/views.py
+++ b/djangoplicity/archives/views.py
@@ -934,13 +934,17 @@ def _has_access_permissions(request, obj, options):
     if not published and not admin_rights:
         return False, "Only admins can access unpublished content."
 
-    if release_date and release_date > now:
-        if embargo_date and embargo_date > now and not can_staging:
+    # Staging
+    if (
+        release_date and release_date > now
+        and embargo_date and embargo_date > now
+    ):
+        if not can_staging:
             return False, "Only staging accounts can access before embargo date."
-        elif not can_embargo:
-            return False, "Only embargo accounts can access before release date."
 
-    elif embargo_date and embargo_date > now and not can_staging:
-        return False, "Only staging accounts can access until embargo ends."
+    # Embargo
+    elif release_date and release_date > now:
+        if not can_embargo:
+            return False, "Only embargo accounts can access before release date."
 
     return True, None

--- a/djangoplicity/archives/views.py
+++ b/djangoplicity/archives/views.py
@@ -827,11 +827,11 @@ class BaseListView(ListView):
         return qs
 
 # Resource proxy view for protected resources
-def resource_proxy_view(request, model, format, id, ext):
+def resource_proxy_view(request, model, format, id, ext=None, resource_path=None):
     from djangoplicity.archives.options import ArchiveOptions
     from djangoplicity.media.consts import MEDIA_CONTENT_SERVERS
 
-    print(f"Resource proxy view: {model}, {format}, {id}, {ext}")
+    print(f"Resource proxy view: {model}, {format}, {id}, {ext}, {resource_path}")
 
     # Get model class
     model_class = _get_model_class(model)
@@ -875,7 +875,13 @@ def resource_proxy_view(request, model, format, id, ext):
             return HttpResponseForbidden(f"Resource not found for format: {format}")
 
         # Generate signed URL
-        presigned_url = content_server.get_signed_url(resource, format, expires_in=3600)
+        presigned_url = content_server.get_signed_url(
+            resource, 
+            format, 
+            expires_in=3600, 
+            resource_path=resource_path
+        )
+
         if not presigned_url:
             return HttpResponseForbidden("Failed to generate signed URL")
         return HttpResponseRedirect(presigned_url)

--- a/djangoplicity/contentserver/admin.py
+++ b/djangoplicity/contentserver/admin.py
@@ -38,7 +38,8 @@ from django.urls import reverse
 from django.conf import settings
 
 from djangoplicity.contentserver.models import ContentServerResource
-from djangoplicity.contentserver.tasks import sync_content_server, sync_content_server_resources_model, update_resource_privacy, refresh_resource_privacy_task
+from djangoplicity.contentserver.tasks import sync_content_server, sync_content_server_resources_model, update_resource_privacy, refresh_resource_privacy_task, set_access_tag_for_resource_task
+from djangoplicity.contentserver.constants import AccessTagControl
 from djangoplicity.archives.utils import initialize_resource
 from django.db.models import Q
 
@@ -123,7 +124,7 @@ class ContentServerResourceAdmin(admin.ModelAdmin):
             'classes': ('collapse',)
         }),
     )
-    actions = ['mark_as_deleted', 'reactivate_resources', 'refresh_resource_privacy']
+    actions = ['mark_as_deleted', 'reactivate_resources', 'refresh_resource_privacy', 'set_public_access_tag_for_resource', 'set_private_access_tag_for_resource']
     
     def get_queryset(self, request):
         """
@@ -213,6 +214,39 @@ class ContentServerResourceAdmin(admin.ModelAdmin):
             f"Privacy refresh scheduled for {queryset.count()} resource(s)."
         )
     refresh_resource_privacy.short_description = "Refresh privacy from content server"
+
+    def set_public_access_tag_for_resource(self, request, queryset):
+        """Set public access tag for selected resources"""
+        for resource in queryset:
+            set_access_tag_for_resource_task.delay(
+                resource._meta.app_label,
+                resource._meta.model_name,
+                resource.pk,
+                AccessTagControl.PUBLIC.value
+            )
+
+        self.message_user(
+            request,
+            f"Public access tag set for {queryset.count()} resource(s)."
+        )
+    set_public_access_tag_for_resource.short_description = "Set public access tag for selected resources in content server"
+
+    def set_private_access_tag_for_resource(self, request, queryset):
+        """Set private access tag for selected resources"""
+        for resource in queryset:
+            set_access_tag_for_resource_task.delay(
+                resource._meta.app_label,
+                resource._meta.model_name,
+                resource.pk,
+                AccessTagControl.PRIVATE.value
+            )
+
+        self.message_user(
+            request,
+            f"Private access tag set for {queryset.count()} resource(s)."
+        )
+    set_private_access_tag_for_resource.short_description = "Set private access tag for selected resources in content server"
+
 
 
 def register_with_admin(admin_site):

--- a/djangoplicity/contentserver/admin.py
+++ b/djangoplicity/contentserver/admin.py
@@ -40,6 +40,7 @@ from django.conf import settings
 from djangoplicity.contentserver.models import ContentServerResource
 from djangoplicity.contentserver.tasks import sync_content_server, sync_content_server_resources_model, update_resource_privacy, refresh_resource_privacy_task
 from djangoplicity.archives.utils import initialize_resource
+from django.db.models import Q
 
 
 class ContentDeliveryAdmin(object):
@@ -58,6 +59,35 @@ class ContentDeliveryAdmin(object):
             update_resource_privacy.delay(obj._meta.app_label, obj._meta.model_name, obj.pk)
     action_resync_resource_privacy.short_description = _("Re-sync resource privacy from content server")
 
+
+class HasRelatedObjectFilter(admin.SimpleListFilter):
+    title = _('Has related object')
+    parameter_name = 'has_related_object'
+
+    def lookups(self, request, model_admin):
+        return [
+            ('yes', _('Yes')),
+            ('no', _('No')),
+        ]
+
+    def queryset(self, request, queryset):
+        if self.value() == 'yes':
+            return queryset.filter(
+                content_type__isnull=False,
+            ).exclude(
+                object_id='',
+            )
+
+        if self.value() == 'no':
+            return queryset.filter(
+                Q(content_type__isnull=True) |
+                Q(object_id__isnull=True) |
+                Q(object_id='')
+            )
+
+        return queryset
+
+
 class ContentServerResourceAdmin(admin.ModelAdmin):
     """
     Admin interface for ContentServerResource model
@@ -67,7 +97,7 @@ class ContentServerResourceAdmin(admin.ModelAdmin):
         'content_server', 'is_public', 'is_active', 'created_at', 'updated_at', 'content_server_link'
     ]
     list_filter = [
-        'format', 'is_directory', 'is_public', 'is_active', 'content_server', 'content_type'
+        'format', 'is_directory', 'is_public', HasRelatedObjectFilter, 'is_active', 'content_server', 'content_type',
     ]
     search_fields = [
         'content_server_path', 'format', 'extension', 'checksum'

--- a/djangoplicity/contentserver/base.py
+++ b/djangoplicity/contentserver/base.py
@@ -432,11 +432,9 @@ class S3ContentServer(ContentServer):
                         local_path = os.path.join(root, filename)
                         
                         s3_key = self.to_s3_path(local_path)
-                        effective_access_tag = (
-                            self._get_zoomable_access_tag(s3_key, access_tag) 
-                            if fmt == 'zoomable' else access_tag
-                        )
-                        self._set_access_tag_for_key(s3_key, effective_access_tag)   
+                        if fmt == 'zoomable' and not self._is_protected_zoom_level(s3_key):
+                            continue  # skip, only set tags for protected zoom levels in zoomable directories
+                        self._set_access_tag_for_key(s3_key, access_tag)
 
             try:
                 is_public = access_tag == AccessTagControl.PUBLIC.value
@@ -772,6 +770,12 @@ class S3ContentServer(ContentServer):
     def _is_protected_zoom_level(self, s3_path: str) -> bool:
         filename = s3_path.split('/')[-1]
         name, ext = os.path.splitext(filename)
+        
+        # Process .xml files (like ImageProperties.xml) in zoomable directories
+        if ext.lower() == '.xml':
+            return True
+        
+        # Process .jpg files with zoom level prefix
         if ext.lower() == '.jpg':
             parts = name.split('-')
             if parts and parts[0].isdigit():

--- a/djangoplicity/contentserver/base.py
+++ b/djangoplicity/contentserver/base.py
@@ -48,7 +48,7 @@ from django.core.cache import cache
 from six import python_2_unicode_compatible
 
 from djangoplicity.contentserver.cdn77_tasks import purge_prefetch
-from djangoplicity.contentserver.constants import AccessTagControl
+from djangoplicity.contentserver.constants import AccessTagControl, ZOOMABLE_PRIVATE_TILE_GROUPS
 from urllib.parse import urlparse, urlunparse
 
 
@@ -154,7 +154,7 @@ class S3ContentServer(ContentServer):
     resource_size_cache_negative_timeout = 60 * 3  # seconds for failures/missing
     has_resource_protection_capabilities = True
 
-    def __init__(self, bucket, base_url=None, bigfiles_base_url=None, bigfiles_limit=None, access_key_id=None, access_key_secret=None, region_name=None, always_public_formats=None):
+    def __init__(self, bucket, base_url=None, bigfiles_base_url=None, bigfiles_limit=None, access_key_id=None, access_key_secret=None, region_name=None, always_public_formats=None, zoomable_private_tile_groups=None):
         config = None
         if region_name:
             config = BotocoreConfig(region_name=region_name)
@@ -164,7 +164,7 @@ class S3ContentServer(ContentServer):
         self.bigfiles_base_url = bigfiles_base_url
         self.bigfiles_limit = bigfiles_limit if bigfiles_limit else 50_000_000_000 # 50GB as default
         self.always_public_formats = always_public_formats if always_public_formats else [] # Void list by default
-
+        self.zoomable_private_tile_groups = zoomable_private_tile_groups if zoomable_private_tile_groups else ZOOMABLE_PRIVATE_TILE_GROUPS # Use default if not specified
     def get_file_size(self, resource, nocache=False):
         from djangoplicity.contentserver.models import ContentServerResource
         """
@@ -348,9 +348,17 @@ class S3ContentServer(ContentServer):
                 for root, dirs, files in os.walk(resource.path):
                     for filename in files:
                         local_path = os.path.join(root, filename)
-                        extra_args = {'Tagging': f'Access={access_tag}'}
+                        s3_key = self.to_s3_path(local_path)
 
-                        self.s3_client.upload_file(local_path, self.bucket, self.to_s3_path(local_path), ExtraArgs=extra_args)
+                        
+                        effective_access_tag = (
+                            self._get_zoomable_access_tag(s3_key, access_tag) 
+                            if fmt == 'zoomable' else access_tag
+                        )
+
+                        extra_args = {'Tagging': f'Access={effective_access_tag}'}
+
+                        self.s3_client.upload_file(local_path, self.bucket, s3_key, ExtraArgs=extra_args)
             else:
                 logger.info('S3ContentServer: Uploading %s to bucket %s:%s', resource.name, self.bucket, remote_path)
                 # TODO: Improve content type detection
@@ -422,7 +430,13 @@ class S3ContentServer(ContentServer):
                 for root, dirs, files in os.walk(resource.path):
                     for filename in files:
                         local_path = os.path.join(root, filename)
-                        self._set_access_tag_for_key(self.to_s3_path(local_path), access_tag)   
+                        
+                        s3_key = self.to_s3_path(local_path)
+                        effective_access_tag = (
+                            self._get_zoomable_access_tag(s3_key, access_tag) 
+                            if fmt == 'zoomable' else access_tag
+                        )
+                        self._set_access_tag_for_key(s3_key, effective_access_tag)   
 
             try:
                 is_public = access_tag == AccessTagControl.PUBLIC.value
@@ -461,7 +475,7 @@ class S3ContentServer(ContentServer):
                     logger.info('S3ContentServer: Setting tag Access=%s for tracked resource %s - format: %s', access_tag, resource, resource.format)
                     
                     if resource.format == 'zoomable':
-                        self.set_access_tag_for_key_in_dir(remote_path, access_tag)
+                        self._set_access_tag_for_key_in_dir(remote_path, access_tag)
                     else:
                         self._set_access_tag_for_key(remote_path, access_tag)
 
@@ -735,7 +749,17 @@ class S3ContentServer(ContentServer):
                 obj_key = obj['Key']
                 if obj_key.endswith('/'):
                     continue
-                self._set_access_tag_for_key(obj_key, access_tag)
+                effective_tag = self._get_zoomable_access_tag(obj_key, access_tag)
+                self._set_access_tag_for_key(obj_key, effective_tag)
+
+    def _get_zoomable_access_tag(self, s3_path, access_tag):
+        parts = s3_path.split('/')
+        for part in parts:
+            if part.startswith('TileGroup'):
+                if part in self.zoomable_private_tile_groups:
+                    return access_tag
+                return AccessTagControl.PUBLIC.value
+        return access_tag
 
 
 class CDN77ContentServer(ContentServer):

--- a/djangoplicity/contentserver/base.py
+++ b/djangoplicity/contentserver/base.py
@@ -334,6 +334,9 @@ class S3ContentServer(ContentServer):
                 continue
             
             remote_path = self.to_s3_path(resource.path)
+            access_tag = instance.get_access_tag_for_format(fmt).value
+            logger.info('S3ContentServer: Setting tag Access=%s for %s. Format: %s', access_tag, instance, fmt)
+
             # There are some archive types that are directories, like the zoomable and the virtualtours
             if os.path.isdir(resource.path):
                 logger.info('S3ContentServer: Uploading directory %s to %s:%s', resource.name, self.bucket, remote_path)
@@ -345,7 +348,9 @@ class S3ContentServer(ContentServer):
                 for root, dirs, files in os.walk(resource.path):
                     for filename in files:
                         local_path = os.path.join(root, filename)
-                        self.s3_client.upload_file(local_path, self.bucket, self.to_s3_path(local_path))
+                        extra_args = {'Tagging': f'Access={access_tag}'}
+
+                        self.s3_client.upload_file(local_path, self.bucket, self.to_s3_path(local_path), ExtraArgs=extra_args)
             else:
                 logger.info('S3ContentServer: Uploading %s to bucket %s:%s', resource.name, self.bucket, remote_path)
                 # TODO: Improve content type detection
@@ -358,13 +363,6 @@ class S3ContentServer(ContentServer):
                     content_type = 'image/gif'
                 elif resource.name.endswith('.mp4'):
                     content_type = 'video/mp4'
-
-                access_tag = instance.get_access_tag_for_format(fmt).value
-                
-                if access_tag:
-                    logger.info('S3ContentServer: Setting tag Access=%s for %s', access_tag, instance)
-                else:
-                    logger.warning('S3ContentServer: No access tag found for %s', instance)
 
                 extra_args = {'ContentType': content_type, 'Tagging': f'Access={access_tag}'}
 

--- a/djangoplicity/contentserver/base.py
+++ b/djangoplicity/contentserver/base.py
@@ -48,7 +48,7 @@ from django.core.cache import cache
 from six import python_2_unicode_compatible
 
 from djangoplicity.contentserver.cdn77_tasks import purge_prefetch
-from djangoplicity.contentserver.constants import AccessTagControl, ZOOMABLE_PUBLIC_ZOOM_LEVELS
+from djangoplicity.contentserver.constants import AccessTagControl, ZOOMABLE_PRIVATE_ZOOM_LEVELS
 from urllib.parse import urlparse, urlunparse
 
 
@@ -154,7 +154,7 @@ class S3ContentServer(ContentServer):
     resource_size_cache_negative_timeout = 60 * 3  # seconds for failures/missing
     has_resource_protection_capabilities = True
 
-    def __init__(self, bucket, base_url=None, bigfiles_base_url=None, bigfiles_limit=None, access_key_id=None, access_key_secret=None, region_name=None, always_public_formats=None, zoomable_public_zoom_levels=None):
+    def __init__(self, bucket, base_url=None, bigfiles_base_url=None, bigfiles_limit=None, access_key_id=None, access_key_secret=None, region_name=None, always_public_formats=None, zoomable_private_zoom_levels=None):
         config = None
         if region_name:
             config = BotocoreConfig(region_name=region_name)
@@ -164,7 +164,7 @@ class S3ContentServer(ContentServer):
         self.bigfiles_base_url = bigfiles_base_url
         self.bigfiles_limit = bigfiles_limit if bigfiles_limit else 50_000_000_000 # 50GB as default
         self.always_public_formats = always_public_formats if always_public_formats else [] # Void list by default
-        self.zoomable_public_zoom_levels = zoomable_public_zoom_levels if zoomable_public_zoom_levels else ZOOMABLE_PUBLIC_ZOOM_LEVELS
+        self.zoomable_private_zoom_levels = zoomable_private_zoom_levels if zoomable_private_zoom_levels else ZOOMABLE_PRIVATE_ZOOM_LEVELS
     def get_file_size(self, resource, nocache=False):
         from djangoplicity.contentserver.models import ContentServerResource
         """
@@ -755,14 +755,14 @@ class S3ContentServer(ContentServer):
 
     def _get_zoomable_access_tag(self, s3_path, access_tag):
         """
-        Determine the access tag for a zoomable tile based on its zoom level and the configured public zoom levels. Just only for sync_resources method.
+        Determine the access tag for a zoomable tile based on its zoom level and the configured private zoom levels. Just only for sync_resources method.
         """
         filename = s3_path.split('/')[-1]
         name, ext = os.path.splitext(filename)
         if ext.lower() == '.jpg':
             parts = name.split('-')
             if parts and parts[0].isdigit():
-                if int(parts[0]) in self.zoomable_public_zoom_levels:
+                if int(parts[0]) in self.zoomable_private_zoom_levels:
                     return access_tag
                 return AccessTagControl.PUBLIC.value
         return access_tag
@@ -779,7 +779,7 @@ class S3ContentServer(ContentServer):
         if ext.lower() == '.jpg':
             parts = name.split('-')
             if parts and parts[0].isdigit():
-                return int(parts[0]) in self.zoomable_public_zoom_levels
+                return int(parts[0]) in self.zoomable_private_zoom_levels
         return False
 
 

--- a/djangoplicity/contentserver/base.py
+++ b/djangoplicity/contentserver/base.py
@@ -461,14 +461,7 @@ class S3ContentServer(ContentServer):
                     logger.info('S3ContentServer: Setting tag Access=%s for tracked resource %s - format: %s', access_tag, resource, resource.format)
                     
                     if resource.format == 'zoomable':
-                        paginator = self.s3_client.get_paginator('list_objects_v2')
-                        dir_path = f"{remote_path}/" if not remote_path.endswith('/') else remote_path
-                        pages = paginator.paginate(Bucket=self.bucket, Prefix=dir_path)
-
-                        for page in pages:
-                            for obj in page.get('Contents', []):
-                                obj_key = obj['Key']
-                                self._set_access_tag_for_key(obj_key, access_tag)
+                        self.set_access_tag_for_key_in_dir(remote_path, access_tag)
                     else:
                         self._set_access_tag_for_key(remote_path, access_tag)
 
@@ -725,6 +718,24 @@ class S3ContentServer(ContentServer):
             Key=key, 
             Tagging={'TagSet': [{'Key': 'Access', 'Value': access_tag}]}
         )
+
+    def _set_access_tag_for_key_in_dir(self, remote_path, access_tag):
+        """Set the access tag for all objects under a directory prefix."""
+        if not remote_path:
+            return
+
+        if not remote_path.endswith('/'):
+            remote_path = f"{remote_path}/"
+
+        paginator = self.s3_client.get_paginator('list_objects_v2')
+        pages = paginator.paginate(Bucket=self.bucket, Prefix=remote_path)
+
+        for page in pages:
+            for obj in page.get('Contents', []):
+                obj_key = obj['Key']
+                if obj_key.endswith('/'):
+                    continue
+                self._set_access_tag_for_key(obj_key, access_tag)
 
 
 class CDN77ContentServer(ContentServer):

--- a/djangoplicity/contentserver/base.py
+++ b/djangoplicity/contentserver/base.py
@@ -592,10 +592,15 @@ class S3ContentServer(ContentServer):
             logger.error('S3ContentServer: Failed to download directory %s: %s', local_dir, str(e))
             raise
     
-    def get_signed_url(self, resource, format, expires_in=3600):
+    def get_signed_url(self, resource, format, expires_in=3600, resource_path=None):
         logger.info("S3ContentServer: Generating signed URL for %s", resource.path)
         try:
-            s3_path = self.to_s3_path(resource.path)
+            s3_path = None
+            if resource_path and format == 'zoomable':
+                s3_path = self.to_s3_path(f"{resource.path}/{resource_path}")
+            else:
+                s3_path = self.to_s3_path(resource.path)
+
             # Get signed url
             signed_url = self.s3_client.generate_presigned_url(
                 'get_object',

--- a/djangoplicity/contentserver/base.py
+++ b/djangoplicity/contentserver/base.py
@@ -48,7 +48,7 @@ from django.core.cache import cache
 from six import python_2_unicode_compatible
 
 from djangoplicity.contentserver.cdn77_tasks import purge_prefetch
-from djangoplicity.contentserver.constants import AccessTagControl, ZOOMABLE_PRIVATE_TILE_GROUPS
+from djangoplicity.contentserver.constants import AccessTagControl, ZOOMABLE_PUBLIC_ZOOM_LEVELS
 from urllib.parse import urlparse, urlunparse
 
 
@@ -154,7 +154,7 @@ class S3ContentServer(ContentServer):
     resource_size_cache_negative_timeout = 60 * 3  # seconds for failures/missing
     has_resource_protection_capabilities = True
 
-    def __init__(self, bucket, base_url=None, bigfiles_base_url=None, bigfiles_limit=None, access_key_id=None, access_key_secret=None, region_name=None, always_public_formats=None, zoomable_private_tile_groups=None):
+    def __init__(self, bucket, base_url=None, bigfiles_base_url=None, bigfiles_limit=None, access_key_id=None, access_key_secret=None, region_name=None, always_public_formats=None, zoomable_public_zoom_levels=None):
         config = None
         if region_name:
             config = BotocoreConfig(region_name=region_name)
@@ -164,7 +164,7 @@ class S3ContentServer(ContentServer):
         self.bigfiles_base_url = bigfiles_base_url
         self.bigfiles_limit = bigfiles_limit if bigfiles_limit else 50_000_000_000 # 50GB as default
         self.always_public_formats = always_public_formats if always_public_formats else [] # Void list by default
-        self.zoomable_private_tile_groups = zoomable_private_tile_groups if zoomable_private_tile_groups else ZOOMABLE_PRIVATE_TILE_GROUPS # Use default if not specified
+        self.zoomable_public_zoom_levels = zoomable_public_zoom_levels if zoomable_public_zoom_levels else ZOOMABLE_PUBLIC_ZOOM_LEVELS
     def get_file_size(self, resource, nocache=False):
         from djangoplicity.contentserver.models import ContentServerResource
         """
@@ -749,17 +749,34 @@ class S3ContentServer(ContentServer):
                 obj_key = obj['Key']
                 if obj_key.endswith('/'):
                     continue
-                effective_tag = self._get_zoomable_access_tag(obj_key, access_tag)
-                self._set_access_tag_for_key(obj_key, effective_tag)
+                
+                if not self._is_protected_zoom_level(obj_key):
+                    continue
+
+                self._set_access_tag_for_key(obj_key, access_tag)
 
     def _get_zoomable_access_tag(self, s3_path, access_tag):
-        parts = s3_path.split('/')
-        for part in parts:
-            if part.startswith('TileGroup'):
-                if part in self.zoomable_private_tile_groups:
+        """
+        Determine the access tag for a zoomable tile based on its zoom level and the configured public zoom levels. Just only for sync_resources method.
+        """
+        filename = s3_path.split('/')[-1]
+        name, ext = os.path.splitext(filename)
+        if ext.lower() == '.jpg':
+            parts = name.split('-')
+            if parts and parts[0].isdigit():
+                if int(parts[0]) in self.zoomable_public_zoom_levels:
                     return access_tag
                 return AccessTagControl.PUBLIC.value
         return access_tag
+    
+    def _is_protected_zoom_level(self, s3_path: str) -> bool:
+        filename = s3_path.split('/')[-1]
+        name, ext = os.path.splitext(filename)
+        if ext.lower() == '.jpg':
+            parts = name.split('-')
+            if parts and parts[0].isdigit():
+                return int(parts[0]) in self.zoomable_public_zoom_levels
+        return False
 
 
 class CDN77ContentServer(ContentServer):

--- a/djangoplicity/contentserver/base.py
+++ b/djangoplicity/contentserver/base.py
@@ -408,29 +408,34 @@ class S3ContentServer(ContentServer):
 
             remote_path = self.to_s3_path(resource.path)
             
-            # Exclude directories (e.g. zoomable and virtualtours)
+            access_tag = instance.get_access_tag_for_format(fmt).value
+            logger.info('S3ContentServer: Setting tag Access=%s for %s - format: %s', access_tag, instance, fmt)
+
+            # For individual files
             if not os.path.isdir(resource.path):
+                self._set_access_tag_for_key(remote_path, access_tag)
+            else:
+            # For directories, we need to list all objects with the prefix and update the tags for each of them (e.g. zoomable)
+                if remote_path == instance.Archive.Meta.root or remote_path == '/' or remote_path == '':
+                    raise Exception('S3ContentServer: remote_path is in root: %s', remote_path)
 
-                access_tag = instance.get_access_tag_for_format(fmt).value
-                logger.info('S3ContentServer: Setting tag Access=%s for %s - format: %s', access_tag, instance, fmt)
-                self.s3_client.put_object_tagging(
-                    Bucket=self.bucket, 
-                    Key=remote_path, 
-                    Tagging={'TagSet': [{'Key': 'Access', 'Value': access_tag}]}
-                )
+                for root, dirs, files in os.walk(resource.path):
+                    for filename in files:
+                        local_path = os.path.join(root, filename)
+                        self._set_access_tag_for_key(self.to_s3_path(local_path), access_tag)   
 
-                try:
-                    is_public = access_tag == AccessTagControl.PUBLIC.value
-                    ContentServerResource.objects.filter(
-                        content_type=content_type,
-                        object_id=instance.pk,
-                        content_server_path=remote_path,
-                        content_server=instance.content_server,
-                        is_active=True
-                    ).update(is_public=is_public)
-                    processed_paths.add(remote_path)
-                except Exception as e:
-                    logger.warning('S3ContentServer: Could not update ContentServerResource privacy record for %s: %s', remote_path, e)
+            try:
+                is_public = access_tag == AccessTagControl.PUBLIC.value
+                ContentServerResource.objects.filter(
+                    content_type=content_type,
+                    object_id=instance.pk,
+                    content_server_path=remote_path,
+                    content_server=instance.content_server,
+                    is_active=True
+                ).update(is_public=is_public)
+                processed_paths.add(remote_path)
+            except Exception as e:
+                logger.warning('S3ContentServer: Could not update ContentServerResource privacy record for %s: %s', remote_path, e)
 
         # Step 2: Update privacy for all tracked resources in ContentServerResource
         # This handles resources that may no longer exist locally but are still tracked
@@ -454,11 +459,18 @@ class S3ContentServer(ContentServer):
 
                     access_tag = instance.get_access_tag_for_format(resource.format).value
                     logger.info('S3ContentServer: Setting tag Access=%s for tracked resource %s - format: %s', access_tag, resource, resource.format)
-                    self.s3_client.put_object_tagging(
-                        Bucket=self.bucket, 
-                        Key=remote_path, 
-                        Tagging={'TagSet': [{'Key': 'Access', 'Value': access_tag}]}
-                    )
+                    
+                    if resource.format == 'zoomable':
+                        paginator = self.s3_client.get_paginator('list_objects_v2')
+                        dir_path = f"{remote_path}/" if not remote_path.endswith('/') else remote_path
+                        pages = paginator.paginate(Bucket=self.bucket, Prefix=dir_path)
+
+                        for page in pages:
+                            for obj in page.get('Contents', []):
+                                obj_key = obj['Key']
+                                self._set_access_tag_for_key(obj_key, access_tag)
+                    else:
+                        self._set_access_tag_for_key(remote_path, access_tag)
 
                     is_public = access_tag == AccessTagControl.PUBLIC.value
                     ContentServerResource.objects.filter(
@@ -701,6 +713,14 @@ class S3ContentServer(ContentServer):
         for tag in tagging.get('TagSet', []):
             if tag.get('Key') == 'Access':
                 return tag.get('Value')
+    
+    def _set_access_tag_for_key(self, key, access_tag):
+        self.s3_client.put_object_tagging(
+            Bucket=self.bucket, 
+            Key=key, 
+            Tagging={'TagSet': [{'Key': 'Access', 'Value': access_tag}]}
+        )
+
 
 class CDN77ContentServer(ContentServer):
     '''

--- a/djangoplicity/contentserver/base.py
+++ b/djangoplicity/contentserver/base.py
@@ -281,10 +281,27 @@ class S3ContentServer(ContentServer):
             return None
 
         try:
-            tagging = self.s3_client.get_object_tagging(Bucket=self.bucket, Key=remote_path)
-            for tag in tagging.get('TagSet', []):
-                if tag.get('Key') == 'Access':
-                    return tag.get('Value')
+            if resource.format == 'zoomable':
+                dir_path = f"{remote_path}/" if not remote_path.endswith('/') else remote_path
+                paginator = self.s3_client.get_paginator('list_objects_v2')
+                pages = paginator.paginate(
+                    Bucket=self.bucket,
+                    Prefix=dir_path,
+                    PaginationConfig={'MaxItems': 1}
+                )
+
+                for page in pages:
+                    contents = page.get('Contents', [])
+                    if not contents:
+                        return AccessTagControl.PUBLIC.value
+
+                    first_object_key = contents[0]['Key']
+
+                    return self._get_access_tag_for_key(first_object_key)
+
+            else:
+                return self._get_access_tag_for_key(remote_path)
+                
         except self.s3_client.exceptions.NoSuchKey:
             return None
         except Exception as e:
@@ -681,6 +698,11 @@ class S3ContentServer(ContentServer):
             logger.error('S3ContentServer: Failed to rename directory %s to %s: %s', old_path, new_path, str(e))
             raise
 
+    def _get_access_tag_for_key(self, key):
+        tagging = self.s3_client.get_object_tagging(Bucket=self.bucket, Key=key)
+        for tag in tagging.get('TagSet', []):
+            if tag.get('Key') == 'Access':
+                return tag.get('Value')
 
 class CDN77ContentServer(ContentServer):
     '''

--- a/djangoplicity/contentserver/constants.py
+++ b/djangoplicity/contentserver/constants.py
@@ -5,3 +5,5 @@ class AccessTagControl(str, Enum):
     PUBLIC = 'Public'
 
 ZOOMABLE_PRIVATE_TILE_GROUPS = ['TileGroup0', 'TileGroup1', 'TileGroup2', 'TileGroup3']
+
+ZOOMABLE_PUBLIC_ZOOM_LEVELS = [0, 1, 2, 3]

--- a/djangoplicity/contentserver/constants.py
+++ b/djangoplicity/contentserver/constants.py
@@ -4,6 +4,4 @@ class AccessTagControl(str, Enum):
     PRIVATE = 'Private'
     PUBLIC = 'Public'
 
-ZOOMABLE_PRIVATE_TILE_GROUPS = ['TileGroup0', 'TileGroup1', 'TileGroup2', 'TileGroup3']
-
-ZOOMABLE_PUBLIC_ZOOM_LEVELS = [0, 1, 2, 3]
+ZOOMABLE_PRIVATE_ZOOM_LEVELS = [0, 1, 2, 3]

--- a/djangoplicity/contentserver/constants.py
+++ b/djangoplicity/contentserver/constants.py
@@ -3,3 +3,5 @@ from enum import Enum
 class AccessTagControl(str, Enum):
     PRIVATE = 'Private'
     PUBLIC = 'Public'
+
+ZOOMABLE_PRIVATE_TILE_GROUPS = ['TileGroup0', 'TileGroup1', 'TileGroup2', 'TileGroup3']

--- a/djangoplicity/contentserver/tasks.py
+++ b/djangoplicity/contentserver/tasks.py
@@ -506,3 +506,41 @@ def refresh_resource_privacy_task(app_label, model_name, pk):
 
     except Exception as e:
         logger.warning(f"Error refreshing privacy for #{pk} Content Server Resource: {e}")
+
+
+@task
+def set_access_tag_for_resource_task(app_label, model_name, pk, access_tag):
+    from django.apps import apps
+
+    try:
+        model = apps.get_model(app_label, model_name)
+        resource = model.objects.get(pk=pk)
+
+        content_server = MEDIA_CONTENT_SERVERS[resource.content_server]
+
+        if (
+            not content_server or 
+            not hasattr(content_server, 'is_publicly_accessible') or 
+            not hasattr(content_server, '_set_access_tag_for_key') or 
+            not hasattr(content_server, '_set_access_tag_for_key_in_dir')
+        ):
+            return
+
+        if resource.format == 'zoomable':
+            content_server._set_access_tag_for_key_in_dir(resource.content_server_path, access_tag)
+            logger.info(f"Set access tag: {access_tag} for zoomable directory resource #{pk} with Object ID {resource.object_id}")
+            
+        else:
+            content_server._set_access_tag_for_key(resource.content_server_path, access_tag)
+            logger.info(f"Set access tag: {access_tag} for #{pk} Content Server Resource with Object ID {resource.object_id}")
+
+        is_public = content_server.is_publicly_accessible(resource)
+
+        if is_public is None:
+            return
+
+        resource.is_public = is_public
+        resource.save(update_fields=['is_public'])
+
+    except Exception as e:
+        logger.warning(f"Error setting access tag: {access_tag} for #{pk} Content Server Resource: {e}")

--- a/djangoplicity/media/views.py
+++ b/djangoplicity/media/views.py
@@ -30,13 +30,14 @@
 # POSSIBILITY OF SUCH DAMAGE
 
 from django.conf import settings
-from django.http import HttpResponseRedirect, Http404
+from django.http import HttpResponseRedirect, Http404, HttpResponseForbidden, HttpResponse
 from django.shortcuts import get_object_or_404
 from django.template import loader
 from django.urls import reverse
 
 from djangoplicity.archives.utils import FormatTokenGenerator
-from djangoplicity.archives.views import GenericDetailView
+from djangoplicity.archives.views import GenericDetailView, _has_access_permissions
+from djangoplicity.archives.options import ArchiveOptions
 from djangoplicity.media.models import Image, ImageProxy
 from djangoplicity.archives.contrib.security.views import serve_file
 
@@ -52,6 +53,12 @@ class ZoomableDetailView( GenericDetailView ):
         return ['zoomable']
 
     def render( self, request, model, obj, state, admin_rights, **kwargs ):
+        options = ArchiveOptions()
+        has_access, reason = _has_access_permissions(request, obj, options)
+        print(f"ZoomableDetailView: has_access={has_access}, reason={reason}")
+        if not has_access:
+            return HttpResponseForbidden(reason)
+
         template_loader = loader
         template_names = ['archives/detail_zoomable.html']
 
@@ -75,6 +82,11 @@ class ZoomableDetailView( GenericDetailView ):
         }
 
         return t.render( context, request )
+
+    def response(self, html, **kwargs):
+        if isinstance(html, HttpResponse):
+            return html
+        return super(ZoomableDetailView, self).response(html, **kwargs)
 
 
 class ImageComparisonFullscreenDetailView( GenericDetailView ):

--- a/djangoplicity/media/views.py
+++ b/djangoplicity/media/views.py
@@ -33,11 +33,14 @@ from django.conf import settings
 from django.http import HttpResponseRedirect, Http404
 from django.shortcuts import get_object_or_404
 from django.template import loader
+from django.urls import reverse
 
 from djangoplicity.archives.utils import FormatTokenGenerator
 from djangoplicity.archives.views import GenericDetailView
 from djangoplicity.media.models import Image, ImageProxy
 from djangoplicity.archives.contrib.security.views import serve_file
+
+from djangoplicity.contentserver.constants import AccessTagControl
 
 
 class ZoomableDetailView( GenericDetailView ):
@@ -53,10 +56,22 @@ class ZoomableDetailView( GenericDetailView ):
         template_names = ['archives/detail_zoomable.html']
 
         t = template_loader.select_template( template_names )
-
+        
+        access_tag = None
+        tiles_proxy_url = None
+        if hasattr(obj, 'get_access_tag_for_format') and obj.get_access_tag_for_format:
+            access_tag = obj.get_access_tag_for_format('zoomable')
+            tiles_proxy_url = reverse('zoomable_resource_proxy', kwargs={
+                'model': obj._meta.model_name,
+                'format': 'zoomable',
+                'id': obj.id,
+                'resource_path': '_',  # placeholder to replace then in openseadragon
+        }).rsplit('/_', 1)[0] + '/'
         # Request context setup
         context = {
             'object': obj,
+            'should_use_zoomable_proxy': access_tag == AccessTagControl.PRIVATE,
+            'tiles_proxy_url': tiles_proxy_url  
         }
 
         return t.render( context, request )


### PR DESCRIPTION
## Changes
- Add `_set_access_tag_for_key` and `_get_access_tag_for_key` helper methods to centralize S3 access tag operations.
- Update `get_resource_privacy` to support zoomable resources stored as directories in S3. The method now retrieves a single file from the directory and uses its Access tag to determine the privacy state, since all files in a zoomable resource are always uploaded and updated together.
- Add support for access tags when synchronizing directory-based resources in `sync_resources.`
- Update `update_resource_privacy` to correctly handle zoomable and other directory-based resources when updating access tags.