### PR TITLE
Feature/Add new video categories: portrait_hd and portrait_hd_broadcast

### DIFF
--- a/djangoplicity/archives/contrib/types/videos.py
+++ b/djangoplicity/archives/contrib/types/videos.py
@@ -244,3 +244,17 @@ class SubtitleType (FileType):
 class AudioTrackType (FileType):
     verbose_name = ugettext_noop(u'Audio Track')
     exts = ['zip', 'wav']
+
+
+class PortraitHDType(FileType):
+    verbose_name = ugettext_noop(u'Portrait HD (H.264)')
+    exts = ['mp4']
+    width = 1080
+    height = 1920
+
+
+class PortraitHDBroadcastType(FileType):
+    verbose_name = ugettext_noop(u'Portrait HD Broadcast (ProRes)')
+    exts = ['mov']
+    width = 1080
+    height = 1920

--- a/djangoplicity/media/models/videos.py
+++ b/djangoplicity/media/models/videos.py
@@ -281,6 +281,10 @@ class Video( ArchiveModel, TranslationModel, ContentDeliveryModel ):
         hd_broadcast_720p50 = ResourceManager( type=types.BroadcastType, verbose_name=_(u"HD Broadcast 720p/50") )  # hd720p50_brodcast
         hd_1080p25_screen = ResourceManager( type=types.FullHDPreview1080p, verbose_name=_(u"Full HD Preview 1080p") )  # hd1080p25_screen
         hd_1080p25_broadcast = ResourceManager( type=types.BroadcastType, verbose_name=_(u"Full HD Broadcast 1080p") )  # hd1080p25_brodcast
+        # Portrait HD
+        portrait_hd = ResourceManager( type=types.PortraitHDType, verbose_name=_(u"Portrait HD Preview")) # portrait_hd
+        portrait_hd_broadcast = ResourceManager( type=types.PortraitHDBroadcastType, verbose_name=_(u"Portrait HD Broadcast")) # portrait_hd_broadcast
+        
         # FULL HD 29,97 FPS
         hd_1080_screen = ResourceManager( type=types.FullHDPreview1080p, verbose_name=_(u"Full HD Preview 1080p") )  # hd1080_screen
         hd_1080_broadcast = ResourceManager( type=types.BroadcastType, verbose_name=_(u"Full HD Broadcast 1080p") )  # hd1080_brodcast

--- a/djangoplicity/media/options/videos.py
+++ b/djangoplicity/media/options/videos.py
@@ -137,10 +137,11 @@ class VideoOptions( ArchiveOptions ):
                 }
         } ),
         ( ugettext_noop('HD'), {
-            'resources': ( shadowbox_link('hd_and_apple', 1280, 720, player='qt'), 'hd_1080p25_screen', 'ext_highres', 'ext_playback'),
+            'resources': ( shadowbox_link('hd_and_apple', 1280, 720, player='qt'), 'hd_1080p25_screen', 'ext_highres', 'portrait_hd', 'ext_playback'),
             'icons': {
                 'shadowbox_link': 'movie',
                 'hd_1080p25_screen': 'movie',
+                'portrait_hd': 'movie',
                 }
         } ),
         ( ugettext_noop( u'BitTorrent Download' ), {
@@ -167,7 +168,7 @@ class VideoOptions( ArchiveOptions ):
                 }
         } ),
         ( ugettext_noop('For Broadcasters'), {
-            'resources': ( 'ultra_hd_broadcast', 'hd_1080p25_broadcast', 'hd_broadcast_720p50', 'hd_broadcast_720p25', 'broadcast_sd', 'broadcast_sd_old', ),
+            'resources': ( 'ultra_hd_broadcast', 'hd_1080p25_broadcast', 'hd_broadcast_720p50', 'hd_broadcast_720p25', 'portrait_hd_broadcast', 'broadcast_sd', 'broadcast_sd_old', ),
             'icons': {
                 'broadcast_sd': 'movie',
                 'broadcast_sd_old': 'movie',
@@ -175,6 +176,7 @@ class VideoOptions( ArchiveOptions ):
                 'hd_broadcast_720p50': 'movie',
                 'hd_1080p25_broadcast': 'movie',
                 'ultra_hd_broadcast': 'movie',
+                'portrait_hd_broadcast': 'movie',
                 }
         } ),
         ( ugettext_noop('Script'), {
@@ -283,11 +285,13 @@ class VideoOptions( ArchiveOptions ):
             # HD
             ( 'hd_and_apple', ( '.mp4', '.m4v' ) ),
             ( 'hd_1080p25_screen', ( '.mp4' ) ),
+            ( 'portrait_hd', ('.mp4')),
             # Broadcast
             ( 'broadcast_sd', ( '.avi', '.mxf', '.mov', '.mp4' ) ),
             ( 'hd_broadcast_720p25', ( '.mxf', '.m2t', '.mov' ) ),
             ( 'hd_broadcast_720p50', ( '.mxf', '.m2t', '.mov' ) ),
             ( 'hd_1080p25_broadcast', ( '.avi', '.mxf' ) ),
+            ( 'portrait_hd_broadcast', ('.mov')),
             # Large
             ( 'large_qt', ( '.mov', ) ),
             # Medium


### PR DESCRIPTION
- Define new types for resource manager
- Link the new video categories to Video model
- Update options to include portrait_hd and portrait_hd_broadcast

## Screenshot

### Template
<img width="275" height="342" alt="Screenshot 2026-06-18 at 2 51 03 PM" src="https://github.com/user-attachments/assets/f473ba99-4f3a-46bc-8d55-88376152357a" />

### Admin
<img width="379" height="519" alt="Screenshot 2026-06-18 at 2 51 40 PM" src="https://github.com/user-attachments/assets/7e984caa-a965-487d-a309-abc573597a4c" />

### Folder in container
<img width="1151" height="80" alt="Screenshot 2026-06-18 at 2 52 30 PM" src="https://github.com/user-attachments/assets/c9b4b5b3-a5ff-4e8d-ab90-d5d838a1fced" />

