### PR TITLE
Fix/Prioritize 2k dome videos for YouTube upload

### DIFF
--- a/djangoplicity/media/models/videos.py
+++ b/djangoplicity/media/models/videos.py
@@ -92,8 +92,8 @@ class Video( ArchiveModel, TranslationModel, ContentDeliveryModel ):
 
     UPLOAD_FORMATS = (
         'vr_8k', 'vr_4k', 'cylindrical_preview', 'ultra_hd',
-        'hd_1080p25_screen', 'hd_1080_screen', 'dome_preview', 'hd_broadcast_720p25',
-        'dome_2kplayback', 'dome_4kplayback', 'hd_and_apple', 'medium_podcast',
+        'hd_1080p25_screen', 'hd_1080_screen', 'hd_broadcast_720p25', 'dome_2kplayback',
+        'dome_4kplayback', 'dome_preview', 'hd_and_apple', 'medium_podcast',
         'ext_highres', 'ext_playback', 'old_video', 'vr_16kmaster', 'vr_8kmaster',
         'vr_4kmaster'
     )


### PR DESCRIPTION
I have reordered the UPLOAD_FORMATS list to ensure that the 'dome_2kplayback' format is checked before other dome formats such as 'dome_preview' (1k) or 'dome_4kplayback' (4k).